### PR TITLE
Update discovery-store-models to v1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "aws-sdk": "^2.53.0",
     "blessed": "^0.1.81",
     "blessed-contrib": "^3.5.5",
-    "discovery-store-models": "git+https://github.com/NYPL-discovery/discovery-store-models.git#v1.3.0",
+    "discovery-store-models": "git+https://github.com/NYPL-discovery/discovery-store-models.git#v1.3.1",
     "dotenv": "^4.0.0",
     "elasticsearch": "^13.0.1",
     "fast-csv": "^2.3.0",


### PR DESCRIPTION
This updates the version for discovery-store-models to v1.3.1 to incorporate a fix for how partner items are identified: https://github.com/NYPL-discovery/discovery-store-models/compare/v1.3.0...v1.3.1 . It has already been tested as an alpha release in QA.