### PR TITLE
SCC-2666 Aeon URLs 

### DIFF
--- a/config/sample.env
+++ b/config/sample.env
@@ -6,3 +6,11 @@ LOGLEVEL=[info (prod)|debug (qa)]
 ELASTIC_RESOURCES_INDEX_NAME=[Name of the Elasticsearch index]
 OUTGOING_SCHEMA_NAME=IndexDocumentProcessed
 OUTGOING_STREAM_NAME=[Name of Kinesis stream to publish to]
+
+# Controls what locations and shelfmarks are considered Aeon requestable:
+AEON_REQUESTABLE_LOCATIONS=scdd1,scdd2
+AEON_REQUESTABLE_SHELFMARK_REGEX=^Sc (Rare|Scores).*
+
+NYPL_OAUTH_KEY=[oauth key]
+NYPL_OAUTH_SECRET=[oauth secret]
+NYPL_OAUTH_URL=https://[fqdn]/

--- a/lib/platform-api-client.js
+++ b/lib/platform-api-client.js
@@ -1,0 +1,30 @@
+const NyplClient = require('@nypl/nypl-data-api-client')
+
+let _instance = null
+
+const instance = () => {
+  if (!_instance) {
+    // Preflight check:
+    if ([
+      'NYPL_API_BASE_URL',
+      'NYPL_OAUTH_KEY',
+      'NYPL_OAUTH_SECRET',
+      'NYPL_OAUTH_URL'
+    ].some((env) => !process.env[env])) {
+      throw new Error('Config error: Missing platform api creds')
+    }
+
+    _instance = new NyplClient({
+      base_url: process.env.NYPL_API_BASE_URL,
+      oauth_key: process.env.NYPL_OAUTH_KEY,
+      oauth_secret: process.env.NYPL_OAUTH_SECRET,
+      oauth_url: process.env.NYPL_OAUTH_URL
+    })
+  }
+
+  return _instance
+}
+
+module.exports = {
+  instance
+}

--- a/lib/serializers/resource-item-serializer.js
+++ b/lib/serializers/resource-item-serializer.js
@@ -149,13 +149,6 @@ class ResourceItemSerializer extends EsSerializer {
         let aeonUrl = aeon856[0].subfields
           .filter((subfield) => subfield.tag === 'u')[0].content
 
-        // Add additional params to Aeon URL:
-        if (this.statements['idBarcode']) {
-          aeonUrl += '&barcode=' + this.statements['idBarcode']
-        }
-        aeonUrl += '&shelfmark=' + this.statements['shelfMark']
-        aeonUrl += '&itemid=' + this.statements['uri'].replace(/^i/, '')
-
         // Add aeonUrl as a statement:
         this.statements['aeonUrl'] = [ aeonUrl ]
 

--- a/lib/serializers/resource-item-serializer.js
+++ b/lib/serializers/resource-item-serializer.js
@@ -4,9 +4,20 @@ const itemFieldMapper = require('./../field-mapper')('item')
 const bibFieldMapper = require('./../field-mapper')('bib')
 const log = require('loglevel')
 const EsSerializer = require('./es-serializer')
+const PlatformApiClient = require('../platform-api-client')
+
+const AEON_REQUESTABLE_LOCATIONS = process.env.AEON_REQUESTABLE_LOCATIONS ? process.env.AEON_REQUESTABLE_LOCATIONS.split(',') : ['scdd1', 'scdd2']
+let AEON_REQUESTABLE_SHELFMARK_REGEX = /^Sc (Rare|Scores).*/
+if (process.env.AEON_REQUESTABLE_SHELFMARK_REGEX) {
+  try {
+    AEON_REQUESTABLE_SHELFMARK_REGEX = new RegExp(process.env.AEON_REQUESTABLE_SHELFMARK_REGEX)
+  } catch (e) {
+    log.error('Failed to parse AEON_REQUESTABLE_SHELFMARK_REGEX as regex: ' + e)
+  }
+}
 
 class ResourceItemSerializer extends EsSerializer {
-  serialize () {
+  serialize (options) {
     const fieldMapping = itemFieldMapper
     // If Item is suppressed, fail serialization
     var suppressed = this.object.literal(fieldMapping.predicateFor('Suppressed')) === 'true'
@@ -95,7 +106,61 @@ class ResourceItemSerializer extends EsSerializer {
       })
     }
 
-    return this.statements
+    // Establish whether item shelf mark matches aeon pattern:
+    const matchesShelfMark = Array.isArray(this.statements['shelfMark']) &&
+      this.statements['shelfMark'].some((shelfMark) => AEON_REQUESTABLE_SHELFMARK_REGEX.test(shelfMark))
+    // Establish whether item location is an Aeon location:
+    const matchesLocation = Array.isArray(this.statements['holdingLocation']) &&
+      this.statements['holdingLocation']
+        .map((loc) => loc.id)
+        .map((loc) => loc.replace(/^loc:/, ''))
+        .some((loc) => AEON_REQUESTABLE_LOCATIONS.includes(loc))
+
+    if (matchesShelfMark && matchesLocation) {
+      return this.addAeonUrl(options.bib)
+    } else {
+      return this.statements
+    }
+  }
+
+  addAeonUrl (bib) {
+    const bibid = bib.uri.replace(/^b/, '')
+
+    // Fetch bib
+    return PlatformApiClient.instance().get(`bibs/sierra-nypl/${bibid}`)
+      .then((bib) => {
+        // Identify all 856 varfields:
+        const var856s = (bib.data.varFields || [])
+          .filter((varField) => varField.marcTag === '856')
+        if (!var856s) return this.statements
+
+        // Identify the Aeon 856 varfield:
+        const aeon856 = var856s
+          .filter((var856) => {
+            return (var856.subfields || []).some((subfields) => {
+              return subfields.tag === 'u' && /^https:\/\/specialcollections\.nypl\.org/.test(subfields.content)
+            })
+          })
+
+        // If no Aeon 856 found, return early:
+        if (aeon856.length === 0) return this.statements
+
+        // Extract Aeon URL:
+        let aeonUrl = aeon856[0].subfields
+          .filter((subfield) => subfield.tag === 'u')[0].content
+
+        // Add additional params to Aeon URL:
+        if (this.statements['idBarcode']) {
+          aeonUrl += '&barcode=' + this.statements['idBarcode']
+        }
+        aeonUrl += '&shelfmark=' + this.statements['shelfMark']
+        aeonUrl += '&itemid=' + this.statements['uri'].replace(/^i/, '')
+
+        // Add aeonUrl as a statement:
+        this.statements['aeonUrl'] = [ aeonUrl ]
+
+        return this.statements
+      })
   }
 }
 
@@ -163,6 +228,6 @@ function parseIdentifierFromStatement (statement) {
   return ret
 }
 
-ResourceItemSerializer.serialize = (item) => (new ResourceItemSerializer(item)).serialize()
+ResourceItemSerializer.serialize = (item, bib) => (new ResourceItemSerializer(item)).serialize({ bib })
 
 module.exports = ResourceItemSerializer

--- a/lib/serializers/resource-serializer.js
+++ b/lib/serializers/resource-serializer.js
@@ -227,7 +227,7 @@ class ResourceSerializer extends EsSerializer {
       this.statements.uris = this.statements.uris.concat(this.object._items.map((i) => [this.statements.uri, i.id].join('-')))
 
       // Serialize each `_items` through ResourceItemSerializer
-      promises.push(Promise.all(this.object._items.map(ResourceItemSerializer.serialize)).then((itemsSerialization) => {
+      promises.push(Promise.all(this.object._items.map((item) => ResourceItemSerializer.serialize(item, this.object))).then((itemsSerialization) => {
         // Filtering out null (suppressed) items
         itemsSerialization = itemsSerialization.filter((r) => r)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,14 +15,142 @@
       }
     },
     "@nypl/nypl-data-api-client": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@nypl/nypl-data-api-client/-/nypl-data-api-client-0.1.1.tgz",
-      "integrity": "sha1-NhSuPBViuP/kaabj5p1Foy9Xrsw=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@nypl/nypl-data-api-client/-/nypl-data-api-client-1.0.4.tgz",
+      "integrity": "sha512-w5TXRkYtppojX8jSuNTtSSXBadlW/beRR693yS8/cppYZHN0ZKGzn7+w7bRetvHcm46T8auw5QVjPN7WQ4x0uw==",
       "requires": {
+        "avsc": "^5.0.2",
+        "colors": "^1.1.2",
+        "diff": "^3.5.0",
+        "dotenv": "^4.0.0",
         "loglevel": "^1.4.1",
+        "loglevel-plugin-prefix": "^0.5.3",
+        "minimist": "^1.2.5",
         "node-cache": "^4.1.1",
         "oauth": "^0.9.15",
-        "request": "^2.81.0"
+        "prompt": "^1.0.0",
+        "request": "^2.88.2"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "aws4": {
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+          "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+        },
+        "colors": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+        },
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+        },
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        },
+        "har-validator": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+          "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+          "requires": {
+            "ajv": "^6.12.3",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
+        "mime-db": {
+          "version": "1.47.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+          "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw=="
+        },
+        "mime-types": {
+          "version": "2.1.30",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
+          "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
+          "requires": {
+            "mime-db": "1.47.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        },
+        "request": {
+          "version": "2.88.2",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+          "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.5.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "@nypl/nypl-streams-client": {
@@ -35,6 +163,19 @@
         "aws-sdk": "^2.50.0",
         "loglevel": "^1.4.1",
         "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "@nypl/nypl-data-api-client": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/@nypl/nypl-data-api-client/-/nypl-data-api-client-0.1.1.tgz",
+          "integrity": "sha1-NhSuPBViuP/kaabj5p1Foy9Xrsw=",
+          "requires": {
+            "loglevel": "^1.4.1",
+            "node-cache": "^4.1.1",
+            "oauth": "^0.9.15",
+            "request": "^2.81.0"
+          }
+        }
       }
     },
     "@sinonjs/formatio": {
@@ -369,8 +510,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base64-js": {
       "version": "1.3.0",
@@ -435,7 +575,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -594,6 +733,12 @@
         "supports-color": "^2.0.0"
       }
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+      "dev": true
+    },
     "charm": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
@@ -635,9 +780,9 @@
       "dev": true
     },
     "clone": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
     "co": {
       "version": "4.6.0",
@@ -692,8 +837,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -751,6 +895,12 @@
         "crc": "^3.4.4",
         "readable-stream": "^2.0.0"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "dev": true
     },
     "cryptiles": {
       "version": "3.1.2",
@@ -848,6 +998,11 @@
       "requires": {
         "type-detect": "^4.0.0"
       }
+    },
+    "deep-equal": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+      "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -1510,8 +1665,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "ftp": {
       "version": "0.3.10",
@@ -1628,7 +1782,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1840,6 +1993,11 @@
         }
       }
     },
+    "i": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
+      "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -1864,7 +2022,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1900,6 +2057,12 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-extended": {
@@ -2249,6 +2412,11 @@
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
       "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po="
     },
+    "loglevel-plugin-prefix": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.5.3.tgz",
+      "integrity": "sha512-zRAJw3WYCQAJ6xfEIi04/oqlmR6jkwg3hmBcMW82Zic3iPWyju1gwntcgic0m5NgqYNJ62alCmb0g/div26WjQ=="
+    },
     "lolex": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.6.0.tgz",
@@ -2305,6 +2473,17 @@
         "node-emoji": "^1.4.1"
       }
     },
+    "md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dev": true,
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
     "memory-streams": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/memory-streams/-/memory-streams-0.1.3.tgz",
@@ -2358,7 +2537,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -2372,7 +2550,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -2380,8 +2557,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -2493,14 +2669,18 @@
     "mute-stream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
-      "dev": true
+      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA="
     },
     "native-promise-only": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
       "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
       "dev": true
+    },
+    "ncp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
+      "integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY="
     },
     "netmask": {
       "version": "1.0.6",
@@ -2528,12 +2708,19 @@
       }
     },
     "node-cache": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-4.2.0.tgz",
-      "integrity": "sha1-SKx5aodOdiWCaSAEo3bSbfqHWBE=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-4.2.1.tgz",
+      "integrity": "sha512-BOb67bWg2dTyax5kdef5WfU3X8xu4wPg+zHzkvls0Q/QpYycIFRLEEIdAx9Wma43DxG6Qzn4illdZoYseKWa4A==",
       "requires": {
         "clone": "2.x",
-        "lodash": "4.x"
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        }
       }
     },
     "node-emoji": {
@@ -6784,7 +6971,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -6893,8 +7079,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -7193,6 +7378,25 @@
       "integrity": "sha1-StIXuzZYvKrplGsXqGaOzYUeE1Y=",
       "dev": true
     },
+    "prompt": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.1.0.tgz",
+      "integrity": "sha512-ec1vUPXCplDBDUVD8uPa3XGA+OzLrO40Vxv3F1uxoiZGkZhdctlK2JotcHq5X6ExjocDOGwGdCSXloGNyU5L1Q==",
+      "requires": {
+        "colors": "^1.1.2",
+        "read": "1.0.x",
+        "revalidator": "0.1.x",
+        "utile": "0.3.x",
+        "winston": "2.x"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+        }
+      }
+    },
     "proxy-agent": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-2.3.1.tgz",
@@ -7238,6 +7442,11 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+    },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -7263,6 +7472,14 @@
         "http-errors": "1.7.3",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
+      }
+    },
+    "read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "requires": {
+        "mute-stream": "~0.0.4"
       }
     },
     "readable-stream": {
@@ -7390,11 +7607,15 @@
         "onetime": "^1.0.0"
       }
     },
+    "revalidator": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+      "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs="
+    },
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
-      "dev": true,
       "requires": {
         "glob": "^7.0.5"
       }
@@ -7925,6 +8146,21 @@
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
     },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "requires": {
+        "punycode": "^2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        }
+      }
+    },
     "url": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
@@ -7954,6 +8190,26 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "utile": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/utile/-/utile-0.3.0.tgz",
+      "integrity": "sha1-E1LDQOuCDk2N26A5pPv6oy7U7zo=",
+      "requires": {
+        "async": "~0.9.0",
+        "deep-equal": "~0.2.1",
+        "i": "0.3.x",
+        "mkdirp": "0.x.x",
+        "ncp": "1.0.x",
+        "rimraf": "2.x.x"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+        }
+      }
     },
     "uuid": {
       "version": "3.2.1",
@@ -8000,8 +8256,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "wrench": {
       "version": "1.3.9",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "author": "NYPL Discovery",
   "dependencies": {
     "@nypl/nypl-core-objects": "^1.3.1",
+    "@nypl/nypl-data-api-client": "^1.0.4",
     "@nypl/nypl-streams-client": "^0.1.2",
     "JSONStream": "^1.2.1",
     "avsc": "^5.0.0",
@@ -24,6 +25,7 @@
   "devDependencies": {
     "chai": "^4.1.2",
     "dotenv": "^4.0.0",
+    "md5": "^2.3.0",
     "minimist": "^1.2.0",
     "mocha": "^3.2.0",
     "node-lambda": "^0.11.3",

--- a/scripts/print-serialized.js
+++ b/scripts/print-serialized.js
@@ -9,7 +9,7 @@
 
 const DiscoveryModels = require('discovery-store-models')
 
-const ResourceSerializer = require('../lib/es-serializer').ResourceSerializer
+const ResourceSerializer = require('../lib/serializers/resource-serializer')
 const envConfigHelper = require('../lib/env-config-helper')
 
 // Parsc cmd line opts:
@@ -27,7 +27,7 @@ if (argv.bnum) {
     .then(() => DiscoveryModels.Bib.byId(argv.bnum))
     .then(ResourceSerializer.serialize)
     .then((doc) => {
-      // console.info(JSON.stringify(doc, null, 2))
+      console.log('Got doc: ', doc)
       process.stdout.write(JSON.stringify(doc, null, 2))
       process.exit()
     })

--- a/scripts/print-serialized.js
+++ b/scripts/print-serialized.js
@@ -27,7 +27,6 @@ if (argv.bnum) {
     .then(() => DiscoveryModels.Bib.byId(argv.bnum))
     .then(ResourceSerializer.serialize)
     .then((doc) => {
-      console.log('Got doc: ', doc)
       process.stdout.write(JSON.stringify(doc, null, 2))
       process.exit()
     })

--- a/test/bib-serializations-test.js
+++ b/test/bib-serializations-test.js
@@ -545,7 +545,7 @@ describe('Bib Serializations', function () {
       it('should set aeonUrl on bib with one item', () => {
         return Bib.byId('b11793485').then((bib) => {
           return ResourceSerializer.serialize(bib).then((serialized) => {
-            assert.strictEqual(serialized.items[0].aeonUrl[0], 'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=[Vocal+and+instrumental+music+/&Site=SCHMA&CallNumber=Sc+Scores+Waller&Author=Waller,+Fats,&Date=1924-1955.&ItemInfo3=https://nypl-sierra-test.nypl.org/record=b117934859&ReferenceNumber=b117934859&ItemInfo1=USE+IN+LIBRARY&ItemISxN=i332995847&Genre=Score&Location=Schomburg+Center&shelfmark=Sc Scores Waller&itemid=33299584')
+            assert.strictEqual(serialized.items[0].aeonUrl[0], 'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=[Vocal+and+instrumental+music+/&Site=SCHMA&CallNumber=Sc+Scores+Waller&Author=Waller,+Fats,&Date=1924-1955.&ItemInfo3=https://nypl-sierra-test.nypl.org/record=b117934859&ReferenceNumber=b117934859&ItemInfo1=USE+IN+LIBRARY&ItemISxN=i332995847&Genre=Score&Location=Schomburg+Center')
           })
         })
       })
@@ -561,7 +561,7 @@ describe('Bib Serializations', function () {
       it('should set aeonUrl on bib with 3 items, one of which is special coll', () => {
         return Bib.byId('b11574666').then((bib) => {
           return ResourceSerializer.serialize(bib).then((serialized) => {
-            assert.strictEqual(serialized.items[0].aeonUrl[0], 'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=The+problem+of+human+destiny++or,+The+end+of+Providence+in+the+world+and+man,&Site=SCHRB&CallNumber=Sc+Rare+124-D+(Dewey,+O.+Problem+of+human+destiny)&Author=Dewey,+Orville,&ItemPlace=New+York,&ItemPublisher=J.+Miller,&Date=1864.&ItemInfo3=https://nypl-sierra-test.nypl.org/record=b115746663&ReferenceNumber=b115746663&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433034100226&ItemISxN=i103641531&Genre=Book-text&Location=Schomburg+Center&barcode=33433034100226&shelfmark=Sc Rare 124-D (Dewey, O. Problem of human destiny)&itemid=10364153')
+            assert.strictEqual(serialized.items[0].aeonUrl[0], 'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=The+problem+of+human+destiny++or,+The+end+of+Providence+in+the+world+and+man,&Site=SCHRB&CallNumber=Sc+Rare+124-D+(Dewey,+O.+Problem+of+human+destiny)&Author=Dewey,+Orville,&ItemPlace=New+York,&ItemPublisher=J.+Miller,&Date=1864.&ItemInfo3=https://nypl-sierra-test.nypl.org/record=b115746663&ReferenceNumber=b115746663&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433034100226&ItemISxN=i103641531&Genre=Book-text&Location=Schomburg+Center')
             assert.strictEqual(serialized.items[0].uri, 'i10364153')
             assert.equal(serialized.items[1].aeonUrl, null)
             assert.strictEqual(serialized.items[1].uri, 'i15002628')

--- a/test/bib-serializations-test.js
+++ b/test/bib-serializations-test.js
@@ -4,10 +4,12 @@ const assert = require('assert')
 const sinon = require('sinon')
 const path = require('path')
 const fs = require('fs')
+const md5 = require('md5')
 
 const ResourceSerializer = require('../lib/serializers/resource-serializer')
 const DiscoveryStoreModels = require('discovery-store-models')
 const { Bib } = DiscoveryStoreModels
+const NyplClient = require('@nypl/nypl-data-api-client')
 
 process.env.LOGLEVEL = process.env.LOGLEVEL || 'error'
 
@@ -25,12 +27,27 @@ let getBibByFixture = function (id) {
   } else console.log(id + ' not found on disk')
 }
 
+const getPlatformEndpointByFixture = function (path) {
+  const fixturePath = `./test/data/platform-endpoint-${md5(path)}.json`
+  if (fs.existsSync(fixturePath)) {
+    let data = JSON.parse(fs.readFileSync(fixturePath))
+    return Promise.resolve(data)
+  } else console.log(`Fixture ${fixturePath} (for ${path}) not found on disk`)
+}
+
 function init () {
   sinon.stub(Bib, 'byId').callsFake(getBibByFixture)
+  sinon.stub(NyplClient.prototype, 'get').callsFake(getPlatformEndpointByFixture)
+
+  process.env.NYPL_API_BASE_URL = 'https://example.com'
+  process.env.NYPL_OAUTH_KEY = 'oauth-key'
+  process.env.NYPL_OAUTH_SECRET = 'oauth-secret'
+  process.env.NYPL_OAUTH_URL = 'https://example.com'
 }
 
 function destroy () {
   Bib.byId.restore()
+  NyplClient.prototype.get.restore()
 }
 
 describe('Bib Serializations', function () {
@@ -520,6 +537,38 @@ describe('Bib Serializations', function () {
         return ResourceSerializer.serialize(bib).then((serialized) => {
           assert.strictEqual(serialized.items[29].physicalLocation[0], '*T-Mss 1991-010')
           assert.strictEqual(serialized.items[29].enumerationChronology[0], 'Box 30')
+        })
+      })
+    })
+
+    describe('Aeon', function () {
+      it('should set aeonUrl on bib with one item', () => {
+        return Bib.byId('b11793485').then((bib) => {
+          return ResourceSerializer.serialize(bib).then((serialized) => {
+            assert.strictEqual(serialized.items[0].aeonUrl[0], 'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=[Vocal+and+instrumental+music+/&Site=SCHMA&CallNumber=Sc+Scores+Waller&Author=Waller,+Fats,&Date=1924-1955.&ItemInfo3=https://nypl-sierra-test.nypl.org/record=b117934859&ReferenceNumber=b117934859&ItemInfo1=USE+IN+LIBRARY&ItemISxN=i332995847&Genre=Score&Location=Schomburg+Center&shelfmark=Sc Scores Waller&itemid=33299584')
+          })
+        })
+      })
+
+      it('should not add aeonUrl to items with invalid 856', () => {
+        return Bib.byId('b11793485-invalid-856').then((bib) => {
+          return ResourceSerializer.serialize(bib).then((serialized) => {
+            assert.equal(serialized.items[0].aeonUrl, null)
+          })
+        })
+      })
+
+      it('should set aeonUrl on bib with 3 items, one of which is special coll', () => {
+        return Bib.byId('b11574666').then((bib) => {
+          return ResourceSerializer.serialize(bib).then((serialized) => {
+            assert.strictEqual(serialized.items[0].aeonUrl[0], 'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=The+problem+of+human+destiny++or,+The+end+of+Providence+in+the+world+and+man,&Site=SCHRB&CallNumber=Sc+Rare+124-D+(Dewey,+O.+Problem+of+human+destiny)&Author=Dewey,+Orville,&ItemPlace=New+York,&ItemPublisher=J.+Miller,&Date=1864.&ItemInfo3=https://nypl-sierra-test.nypl.org/record=b115746663&ReferenceNumber=b115746663&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433034100226&ItemISxN=i103641531&Genre=Book-text&Location=Schomburg+Center&barcode=33433034100226&shelfmark=Sc Rare 124-D (Dewey, O. Problem of human destiny)&itemid=10364153')
+            assert.strictEqual(serialized.items[0].uri, 'i10364153')
+            assert.equal(serialized.items[1].aeonUrl, null)
+            assert.strictEqual(serialized.items[1].uri, 'i15002628')
+            assert.equal(serialized.items[2].aeonUrl, null)
+            assert.strictEqual(serialized.items[2].uri, 'i28230569')
+            assert.strictEqual(serialized.items.length, 4)
+          })
         })
       })
     })

--- a/test/data/b11574666.json
+++ b/test/data/b11574666.json
@@ -1,0 +1,590 @@
+{
+  "subject_id": "b11574666",
+  "bib_statements": [
+    {
+      "bn": null,
+      "id": "carriertypes:nc",
+      "la": "volume",
+      "li": null,
+      "pr": "bf:carrier",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "24 cm.",
+      "pr": "bf:dimensions",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": "urn:biblevel:m",
+      "la": "monograph/item",
+      "li": null,
+      "pr": "bf:issuance",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": "mediatypes:n",
+      "la": "unmediated",
+      "li": null,
+      "pr": "bf:media",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Lowell lectures",
+      "pr": "bf:seriesStatement",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "1864",
+      "pr": "dbo:startDate",
+      "ty": "xsd:integer"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Dewey, Orville, 1794-1882.",
+      "pr": "dc:creator",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "1864",
+      "pr": "dc:date",
+      "ty": "xsd:integer"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Providence and government of God.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Slavery.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Colonization.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "End of Providence in the world and man.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "1864",
+      "pr": "dcterms:created",
+      "ty": "xsd:integer"
+    },
+    {
+      "bn": null,
+      "id": "11574666",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier",
+      "ty": "nypl:Bnumber"
+    },
+    {
+      "bn": null,
+      "id": "11023105",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier",
+      "ty": "bf:Lccn"
+    },
+    {
+      "bn": null,
+      "id": "lang:eng",
+      "la": "English",
+      "li": null,
+      "pr": "dcterms:language",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "The problem of human destiny; or, The end of Providence in the world and man,",
+      "pr": "dcterms:title",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": "resourcetypes:txt",
+      "la": "Text",
+      "li": null,
+      "pr": "dcterms:type",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": "loc:scd",
+      "la": "Schomburg Center - Manuscripts & Archives",
+      "li": null,
+      "pr": "nypl:catalogBibLocation",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": "loc:mal",
+      "la": "Schwarzman Building - Main Reading Room 315",
+      "li": null,
+      "pr": "nypl:catalogBibLocation",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "viii, 275 p.",
+      "pr": "nypl:extent",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "BD541 .D5",
+      "pr": "nypl:lccClassification",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "New York,",
+      "pr": "nypl:placeOfPublication",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "New York, J. Miller, 1864.",
+      "pr": "nypl:publicationStatement",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "J. Miller,",
+      "pr": "nypl:role-publisher",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Sc Rare 124-D (Dewey, O. Problem of human destiny)",
+      "pr": "nypl:shelfMark",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed",
+      "ty": "xsd:boolean"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "The problem of human destiny; or, The end of Providence in the world and man, by Rev. Orville Dewey, D.D.",
+      "pr": "nypl:titleDisplay",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Lowell Institute lectures.",
+      "pr": "nypl:uniformTitle",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": "nypl:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdfs:type",
+      "ty": null
+    }
+  ],
+  "item_statements": [
+    {
+      "s": "i11574666-e",
+      "bn": null,
+      "id": null,
+      "la": "Full text available via HathiTrust",
+      "li": "http://hdl.handle.net/2027/nyp.33433006055358",
+      "pr": "bf:electronicLocator",
+      "ty": null
+    },
+    {
+      "s": "i11574666-e",
+      "bn": null,
+      "id": "urn:bnum:b11574666",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum",
+      "ty": null
+    },
+    {
+      "s": "i11574666-e",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed",
+      "ty": "xsd:boolean"
+    },
+    {
+      "s": "i11574666-e",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdfs:type",
+      "ty": null
+    },
+    {
+      "s": "i28230569",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status",
+      "ty": null
+    },
+    {
+      "s": "i28230569",
+      "bn": null,
+      "id": "urn:barcode:33433096573401",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier",
+      "ty": null
+    },
+    {
+      "s": "i28230569",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage",
+      "ty": null
+    },
+    {
+      "s": "i28230569",
+      "bn": null,
+      "id": "urn:bnum:b11574666",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum",
+      "ty": null
+    },
+    {
+      "s": "i28230569",
+      "bn": null,
+      "id": "catalogItemType:2",
+      "la": "book non-circ",
+      "li": null,
+      "pr": "nypl:catalogItemType",
+      "ty": null
+    },
+    {
+      "s": "i28230569",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation",
+      "ty": null
+    },
+    {
+      "s": "i28230569",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner",
+      "ty": null
+    },
+    {
+      "s": "i28230569",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable",
+      "ty": "xsd:boolean"
+    },
+    {
+      "s": "i28230569",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "YFH (Dewey, O. Problem of human destiny. 1864)",
+      "pr": "nypl:shelfMark",
+      "ty": null
+    },
+    {
+      "s": "i28230569",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed",
+      "ty": "xsd:boolean"
+    },
+    {
+      "s": "i28230569",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type",
+      "ty": null
+    },
+    {
+      "s": "i15002628",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status",
+      "ty": null
+    },
+    {
+      "s": "i15002628",
+      "bn": null,
+      "id": "urn:barcode:33433070237700",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier",
+      "ty": null
+    },
+    {
+      "s": "i15002628",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage",
+      "ty": null
+    },
+    {
+      "s": "i15002628",
+      "bn": null,
+      "id": "urn:bnum:b11574666",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum",
+      "ty": null
+    },
+    {
+      "s": "i15002628",
+      "bn": null,
+      "id": "catalogItemType:2",
+      "la": "book non-circ",
+      "li": null,
+      "pr": "nypl:catalogItemType",
+      "ty": null
+    },
+    {
+      "s": "i15002628",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation",
+      "ty": null
+    },
+    {
+      "s": "i15002628",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner",
+      "ty": null
+    },
+    {
+      "s": "i15002628",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable",
+      "ty": "xsd:boolean"
+    },
+    {
+      "s": "i15002628",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "YCO (Dewey, O. Problem of human destiny. 1864)",
+      "pr": "nypl:shelfMark",
+      "ty": null
+    },
+    {
+      "s": "i15002628",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed",
+      "ty": "xsd:boolean"
+    },
+    {
+      "s": "i15002628",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type",
+      "ty": null
+    },
+    {
+      "s": "i10364153",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status",
+      "ty": null
+    },
+    {
+      "s": "i10364153",
+      "bn": null,
+      "id": "urn:barcode:33433034100226",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier",
+      "ty": null
+    },
+    {
+      "s": "i10364153",
+      "bn": null,
+      "id": "accessMessage:1",
+      "la": "Use in library",
+      "li": null,
+      "pr": "nypl:accessMessage",
+      "ty": null
+    },
+    {
+      "s": "i10364153",
+      "bn": null,
+      "id": "urn:bnum:b11574666",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum",
+      "ty": null
+    },
+    {
+      "s": "i10364153",
+      "bn": null,
+      "id": "catalogItemType:2",
+      "la": "book non-circ",
+      "li": null,
+      "pr": "nypl:catalogItemType",
+      "ty": null
+    },
+    {
+      "s": "i10364153",
+      "bn": null,
+      "id": "loc:scdd2",
+      "la": "Schomburg Center - Manuscripts & Archives",
+      "li": null,
+      "pr": "nypl:holdingLocation",
+      "ty": null
+    },
+    {
+      "s": "i10364153",
+      "bn": null,
+      "id": "orgs:1116",
+      "la": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division",
+      "li": null,
+      "pr": "nypl:owner",
+      "ty": null
+    },
+    {
+      "s": "i10364153",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:requestable",
+      "ty": "xsd:boolean"
+    },
+    {
+      "s": "i10364153",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Sc Rare 124-D (Dewey, O. Problem of human destiny)",
+      "pr": "nypl:shelfMark",
+      "ty": null
+    },
+    {
+      "s": "i10364153",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed",
+      "ty": "xsd:boolean"
+    },
+    {
+      "s": "i10364153",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdfs:type",
+      "ty": null
+    },
+    {
+      "s": "i10364153",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type",
+      "ty": null
+    }
+  ],
+  "holding_statements": []
+}

--- a/test/data/b11793485-invalid-856.json
+++ b/test/data/b11793485-invalid-856.json
@@ -1,0 +1,1631 @@
+{
+  "subject_id": "b11793485-invalid-856",
+  "bib_statements": [
+    {
+      "bn": null,
+      "id": "carriertypes:nc",
+      "la": "volume",
+      "li": null,
+      "pr": "bf:carrier",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "32 cm. or smaller.",
+      "pr": "bf:dimensions",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": "urn:biblevel:c",
+      "la": "collection",
+      "li": null,
+      "pr": "bf:issuance",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": "mediatypes:n",
+      "la": "unmediated",
+      "li": null,
+      "pr": "bf:media",
+      "ty": null
+    },
+    {
+      "bn": [
+        {
+          "id": null,
+          "la": null,
+          "li": "Note",
+          "pr": "bf:noteType",
+          "ty": null
+        },
+        {
+          "id": null,
+          "la": null,
+          "li": "Some items with piano acc.",
+          "pr": "rdfs:label",
+          "ty": null
+        },
+        {
+          "id": "bf:Note",
+          "la": null,
+          "li": null,
+          "pr": "rdf:type",
+          "ty": null
+        }
+      ],
+      "id": "b11793485#1.0000",
+      "la": null,
+      "li": null,
+      "pr": "bf:note",
+      "ty": null
+    },
+    {
+      "bn": [
+        {
+          "id": null,
+          "la": null,
+          "li": "Note",
+          "pr": "bf:noteType",
+          "ty": null
+        },
+        {
+          "id": null,
+          "la": null,
+          "li": "By Thomas Waller, Harry Brooks, John Holmes, Harry Link, Donald Redman, J.C. Johnson, Alexander Hill, Benny Carter, Ed Kirkeby, Clarence Williams, Harold Arlen, J. Turner Layton Jimmy McHugh, Isham Jones, Friedrich von Flotow, M.W. Balfe, Camille Saint-Saens, Pietro Mascagni, R. Drigo, Guiseppe Verdi, Ruggiero Leoncavallo and Charles Gounod.",
+          "pr": "rdfs:label",
+          "ty": null
+        },
+        {
+          "id": "bf:Note",
+          "la": null,
+          "li": null,
+          "pr": "rdf:type",
+          "ty": null
+        }
+      ],
+      "id": "b11793485#1.0001",
+      "la": null,
+      "li": null,
+      "pr": "bf:note",
+      "ty": null
+    },
+    {
+      "bn": [
+        {
+          "id": null,
+          "la": null,
+          "li": "Note",
+          "pr": "bf:noteType",
+          "ty": null
+        },
+        {
+          "id": null,
+          "la": null,
+          "li": "Some items transcribed by Fats Waller.",
+          "pr": "rdfs:label",
+          "ty": null
+        },
+        {
+          "id": "bf:Note",
+          "la": null,
+          "li": null,
+          "pr": "rdf:type",
+          "ty": null
+        }
+      ],
+      "id": "b11793485#1.0002",
+      "la": null,
+      "li": null,
+      "pr": "bf:note",
+      "ty": null
+    },
+    {
+      "bn": [
+        {
+          "id": null,
+          "la": null,
+          "li": "Note",
+          "pr": "bf:noteType",
+          "ty": null
+        },
+        {
+          "id": null,
+          "la": null,
+          "li": "Words by Andy Razaf, George Brown, Joe Young, Alexander Hill, Ray Klages, Billy Rose, George Marion, Jr., and R. Stanley Adams",
+          "pr": "rdfs:label",
+          "ty": null
+        },
+        {
+          "id": "bf:Note",
+          "la": null,
+          "li": null,
+          "pr": "rdf:type",
+          "ty": null
+        }
+      ],
+      "id": "b11793485#1.0003",
+      "la": null,
+      "li": null,
+      "pr": "bf:note",
+      "ty": null
+    },
+    {
+      "bn": [
+        {
+          "id": null,
+          "la": null,
+          "li": "Note",
+          "pr": "bf:noteType",
+          "ty": null
+        },
+        {
+          "id": null,
+          "la": null,
+          "li": "Various publishers, chiefly New York: Mills Music, Inc.",
+          "pr": "rdfs:label",
+          "ty": null
+        },
+        {
+          "id": "bf:Note",
+          "la": null,
+          "li": null,
+          "pr": "rdf:type",
+          "ty": null
+        }
+      ],
+      "id": "b11793485#1.0004",
+      "la": null,
+      "li": null,
+      "pr": "bf:note",
+      "ty": null
+    },
+    {
+      "bn": [
+        {
+          "id": null,
+          "la": null,
+          "li": "Note",
+          "pr": "bf:noteType",
+          "ty": null
+        },
+        {
+          "id": null,
+          "la": null,
+          "li": "Some songs from the musical revues \"Hot chocolates\" \"Load of coal,\" \"Early to bed,\" \"Spades are trump\" and from the musical motion picture \"Stormy Weather.\".",
+          "pr": "rdfs:label",
+          "ty": null
+        },
+        {
+          "id": "bf:Note",
+          "la": null,
+          "li": null,
+          "pr": "rdf:type",
+          "ty": null
+        }
+      ],
+      "id": "b11793485#1.0005",
+      "la": null,
+      "li": null,
+      "pr": "bf:note",
+      "ty": null
+    },
+    {
+      "bn": [
+        {
+          "id": null,
+          "la": null,
+          "li": "Note",
+          "pr": "bf:noteType",
+          "ty": null
+        },
+        {
+          "id": null,
+          "la": null,
+          "li": "Some items are arrangements of arias from the operas \"Martha\", \"The Bohemian Girl,\" \"Lucia di Lammermour,\" \"Cavalleria Rusticana,\" \"Les Millions D'Arlequin\", \"Il Trovatore\", \"I Pagliacci,\" \"Rigoletto\" and \"Faust.\"",
+          "pr": "rdfs:label",
+          "ty": null
+        },
+        {
+          "id": "bf:Note",
+          "la": null,
+          "li": null,
+          "pr": "rdf:type",
+          "ty": null
+        }
+      ],
+      "id": "b11793485#1.0006",
+      "la": null,
+      "li": null,
+      "pr": "bf:note",
+      "ty": null
+    },
+    {
+      "bn": [
+        {
+          "id": null,
+          "la": null,
+          "li": "Note",
+          "pr": "bf:noteType",
+          "ty": null
+        },
+        {
+          "id": null,
+          "la": null,
+          "li": "As featured by Fats Waller, Jo Stafford, Merle Johnston, Lew Conrad, Eddie Peabody, Gene Austin, George Olsen, Gray Gordon's Tic-Toc Rhythm Orchestra, Julian Woodworth and his Clintonians, Paul Tremaine and his Aristocrats of Modern Music, George Hall and his orchestra, Heller Sisters and Brother Lynch, Ozzie Nelson and his Orchestra and Leo Reisman and his Victor Recording Orchestra.",
+          "pr": "rdfs:label",
+          "ty": null
+        },
+        {
+          "id": "bf:Note",
+          "la": null,
+          "li": null,
+          "pr": "rdf:type",
+          "ty": null
+        }
+      ],
+      "id": "b11793485#1.0007",
+      "la": null,
+      "li": null,
+      "pr": "bf:note",
+      "ty": null
+    },
+    {
+      "bn": [
+        {
+          "id": null,
+          "la": null,
+          "li": "Note",
+          "pr": "bf:noteType",
+          "ty": null
+        },
+        {
+          "id": null,
+          "la": null,
+          "li": "Cover illustrations include several caricatured drawings of Fats Waller playing the piano; photographs of Fats Waller, Lena Horne, Bill Robinson, Cab Calloway, Jo Stafford, Merle Johnston, Lew Conrad, Eddie Peabody, Gene Austin, George Olsen, Gray Gordon, Julian Woodworth, Paul Tremaine, George Hall, Ozzie Nelson, Leo Reisman and Haller Sisters and Brother Lynch on covers.",
+          "pr": "rdfs:label",
+          "ty": null
+        },
+        {
+          "id": "bf:Note",
+          "la": null,
+          "li": null,
+          "pr": "rdf:type",
+          "ty": null
+        }
+      ],
+      "id": "b11793485#1.0008",
+      "la": null,
+      "li": null,
+      "pr": "bf:note",
+      "ty": null
+    },
+    {
+      "bn": [
+        {
+          "id": null,
+          "la": null,
+          "li": "Note",
+          "pr": "bf:noteType",
+          "ty": null
+        },
+        {
+          "id": null,
+          "la": null,
+          "li": "Title and first line finding aids available.",
+          "pr": "rdfs:label",
+          "ty": null
+        },
+        {
+          "id": "bf:Note",
+          "la": null,
+          "li": null,
+          "pr": "rdf:type",
+          "ty": null
+        }
+      ],
+      "id": "b11793485#1.0009",
+      "la": null,
+      "li": null,
+      "pr": "bf:note",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "1955",
+      "pr": "dbo:endDate",
+      "ty": "xsd:integer"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "1924",
+      "pr": "dbo:startDate",
+      "ty": "xsd:integer"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Link, Harry, 1896-1956.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Brooks, Harry, 1895-1970.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Holmes, John.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Redman, Don.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Johnson, J. C., 1896-1981.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Hill, Alexander.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Carter, Benny.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Kirkeby, Ed.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Williams, Clarence, 1893-1965.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Arlen, Harold, 1905-1986.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Layton, Turner",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "McHugh, Jimmy, 1894-1969.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Jones, Isham, 1894-1956.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Flowtow, Friedrich von, 1812-1883.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Balfe, M. W. (Michael William), 1808-1870.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Saint-Saëns, Camille, 1835-1921.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Mascagni, Pietro, 1863-1945.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Drigo, Riccardo, 1846-1930.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Verdi, Giuseppe, 1813-1901.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Leoncavallo, Ruggiero, 1858-1919.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Gounod, Charles, 1818-1893.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Razaf, Andy, 1895-1973.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Brown, George.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Young, Joe, 1889-1939.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Klages, Roy.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Rose, Billy, 1899-1966.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Marion, George, Jr., 1899-1968,",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Adams, R. Stanley.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Stafford, Jo.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Johnston, Merle.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Conrad, Lew.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Peabody, Eddie.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Austin, Gene.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Hill, Alexander.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Gordon Gray.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Nelson, Ozzie, 1906-1975.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Olsen, George.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Hall, George.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Reisman, Leo, 1897-1961.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Woodworth, Julian.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Tremaine, Paul.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Clarence Williams Music Company.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Heller Sisters and Brother Lynch. prf",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Tic-Toc Rhythm Orchestra. prf",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Clintonians. prf",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Aristocrats of Modern Music. prf",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Victor Recording Orchestra. prf",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Waller, Fats, 1904-1943.",
+      "pr": "dc:creator",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "1924",
+      "pr": "dc:date",
+      "ty": "xsd:integer"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Waller, Fats, 1904-1943.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Harne, Lena.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Robinson, Bill, 1878-1949.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Calloway, Cab, 1907-1994.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Stafford, Jo.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Johnston, Merle.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Conrad, Lew.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Peabody, Eddie.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Austin, Gene.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Olsen, George.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Hall, George.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Nelson, Ozzie, 1906-1975.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Reisman, Leo, 1897-1961.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Tremaine, Paul.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Gordon Gray.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Woodworth, Julian.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Heller Sisters and Brother Lynch.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "African Americans -- Music.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Songs with piano.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Piano music.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Operas -- Excerpts, Arranged.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Musicals -- Excerpts -- Vocal scores with piano.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Popular music -- 1921-1930.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Popular music -- 1931-1940.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Popular music -- 1941-1950.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Popular music -- 1951-1960.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Selections",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Ain't cha glad?",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Ain't misbehavin'.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "(What did I do to be) Alone and blue.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Angeline.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Anita.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Apple of my eye.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "(What did I do to be so) Black and blue.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Bohemian girl.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Cavalleria Rusticana.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Concentratin'.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Early to bed.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Fats Waller album of favorite songs and piano transcriptions.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Fats Waller's original piano conceptions.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Fats Waller's Scottish piano conceptions.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Fats Waller's Swing sessions for the piano.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Faust.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Foolin' myself.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Francis & Day's album of Fats Waller's musical rhythms.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Home alone blues.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Honeysuckle rose.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Hot chocolates.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "I'm crazy 'bout my baby.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "I'm more than satisfied.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "I've got a feeling I'm falling.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "I pagliacci.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "If it ain't love.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Il trovatore.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Joint is jumpin.'",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Keep a song in your soul.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Keepin' out of mischief now.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Ladies who sing with the band.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Load of coal.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Lucia di Lammermoor.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Martha.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Millions D'arlequin.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Moppin' and boppin'.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "My fate is in your hands.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "My heart's at ease.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "On rainy days.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Rigoletto.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Rollin' down the river.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Sheltered by the stars.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Sittin' up waitin' for you.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Slightly less than wonderful.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Smashing thirds.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Spades are trump.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Spider and fly.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Squeeze me.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Strange as it seems.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Stormy weather.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Swinging the operas.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Take it from me.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Tall timber.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "There's a man in my life.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "This is so nice.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "When Gabriel blows his horn.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "When the nylons bloom again.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "1924",
+      "pr": "dcterms:created",
+      "ty": "xsd:integer"
+    },
+    {
+      "bn": null,
+      "id": "11793485",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier",
+      "ty": "nypl:Bnumber"
+    },
+    {
+      "bn": null,
+      "id": "lang:eng",
+      "la": "English",
+      "li": null,
+      "pr": "dcterms:language",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Ain't cha glad? (4 copies) -- Ain't misbehavin' -- (What did I do to be) Alone and blue -- Angeline -- Anita -- The apple of my eye -- (What did I do to be so) Black and blue. -- Concentratin' (on you) -- The Fats Waller album of favorite songs and piano transcriptions -- Fats Waller's original piano conceptions -- Fats Waller's Scottish piano conceptions -- Fats Waller's swing sessions for the piano -- Foolin' myself -- Francis & Day's album of Fats Waller Musical Rhythms. -- Home alone blues -- Honeysuckle rose (4 copies) -- I'm crazy 'bout my baby (3 copies) -- I'm more than satisfied -- I've got a feeling I'm falling -- If it aint love (2 copies) -- The joint is jumpin' -- Keep a song in your soul -- Keepin' out of mischief now -- (3 copies) -- The ladies who sing with the band -- (2 copies) -- Moppin' and boppin' -- My fate is in your hands (3 copies) -- My heart's at ease -- On rainy days -- Rollin' down the river (3 copies) -- Sheltered by the stars (3 copies) -- Sittin' up waitin' for you -- Slightly less than wonderful (2 copies) -- Smashing thirds -- The spider and the fly (5 copies) -- Squeeze me -- Strange as it seems -- Swingin' the operas -- Take it from me (3 copies) -- Tall timber (2 copies) -- There's a man in my life (2 copies) -- This is so nice (4 copies) -- When Gabriel blows his horn -- When the nylons bloom again.",
+      "pr": "dcterms:tableOfContents",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "[Vocal and instrumental music",
+      "pr": "dcterms:title",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": "resourcetypes:not",
+      "la": "Notated music",
+      "li": null,
+      "pr": "dcterms:type",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": "loc:scd",
+      "la": "Schomburg Center - Manuscripts & Archives",
+      "li": null,
+      "pr": "nypl:catalogBibLocation",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "73 scores : col. ill., ports. ;",
+      "pr": "nypl:extent",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "1924-1955.",
+      "pr": "nypl:publicationStatement",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Sc Scores Waller",
+      "pr": "nypl:shelfMark",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed",
+      "ty": "xsd:boolean"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "[Vocal and instrumental music / composed, arranged, transcribed and performed by Fats Waller and others].",
+      "pr": "nypl:titleDisplay",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Selections",
+      "pr": "nypl:uniformTitle",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": "nypl:Collection",
+      "la": null,
+      "li": null,
+      "pr": "rdfs:type",
+      "ty": null
+    }
+  ],
+  "item_statements": [
+    {
+      "s": "i33299584",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Sc Scores Waller",
+      "pr": "bf:physicalLocation",
+      "ty": null
+    },
+    {
+      "s": "i33299584",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available",
+      "li": null,
+      "pr": "bf:status",
+      "ty": null
+    },
+    {
+      "s": "i33299584",
+      "bn": null,
+      "id": "accessMessage:1",
+      "la": "Use in library",
+      "li": null,
+      "pr": "nypl:accessMessage",
+      "ty": null
+    },
+    {
+      "s": "i33299584",
+      "bn": null,
+      "id": "urn:bnum:b11793485",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum",
+      "ty": null
+    },
+    {
+      "s": "i33299584",
+      "bn": null,
+      "id": "catalogItemType:7",
+      "la": "printed music, non-circ",
+      "li": null,
+      "pr": "nypl:catalogItemType",
+      "ty": null
+    },
+    {
+      "s": "i33299584",
+      "bn": null,
+      "id": "loc:scdd2",
+      "la": "Schomburg Center - Manuscripts & Archives",
+      "li": null,
+      "pr": "nypl:holdingLocation",
+      "ty": null
+    },
+    {
+      "s": "i33299584",
+      "bn": null,
+      "id": "orgs:1116",
+      "la": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division",
+      "li": null,
+      "pr": "nypl:owner",
+      "ty": null
+    },
+    {
+      "s": "i33299584",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:requestable",
+      "ty": "xsd:boolean"
+    },
+    {
+      "s": "i33299584",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Sc Scores Waller",
+      "pr": "nypl:shelfMark",
+      "ty": null
+    },
+    {
+      "s": "i33299584",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed",
+      "ty": "xsd:boolean"
+    },
+    {
+      "s": "i33299584",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdfs:type",
+      "ty": null
+    }
+  ],
+  "holding_statements": []
+}

--- a/test/data/b11793485.json
+++ b/test/data/b11793485.json
@@ -1,0 +1,1631 @@
+{
+  "subject_id": "b11793485",
+  "bib_statements": [
+    {
+      "bn": null,
+      "id": "carriertypes:nc",
+      "la": "volume",
+      "li": null,
+      "pr": "bf:carrier",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "32 cm. or smaller.",
+      "pr": "bf:dimensions",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": "urn:biblevel:c",
+      "la": "collection",
+      "li": null,
+      "pr": "bf:issuance",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": "mediatypes:n",
+      "la": "unmediated",
+      "li": null,
+      "pr": "bf:media",
+      "ty": null
+    },
+    {
+      "bn": [
+        {
+          "id": null,
+          "la": null,
+          "li": "Note",
+          "pr": "bf:noteType",
+          "ty": null
+        },
+        {
+          "id": null,
+          "la": null,
+          "li": "Some items with piano acc.",
+          "pr": "rdfs:label",
+          "ty": null
+        },
+        {
+          "id": "bf:Note",
+          "la": null,
+          "li": null,
+          "pr": "rdf:type",
+          "ty": null
+        }
+      ],
+      "id": "b11793485#1.0000",
+      "la": null,
+      "li": null,
+      "pr": "bf:note",
+      "ty": null
+    },
+    {
+      "bn": [
+        {
+          "id": null,
+          "la": null,
+          "li": "Note",
+          "pr": "bf:noteType",
+          "ty": null
+        },
+        {
+          "id": null,
+          "la": null,
+          "li": "By Thomas Waller, Harry Brooks, John Holmes, Harry Link, Donald Redman, J.C. Johnson, Alexander Hill, Benny Carter, Ed Kirkeby, Clarence Williams, Harold Arlen, J. Turner Layton Jimmy McHugh, Isham Jones, Friedrich von Flotow, M.W. Balfe, Camille Saint-Saens, Pietro Mascagni, R. Drigo, Guiseppe Verdi, Ruggiero Leoncavallo and Charles Gounod.",
+          "pr": "rdfs:label",
+          "ty": null
+        },
+        {
+          "id": "bf:Note",
+          "la": null,
+          "li": null,
+          "pr": "rdf:type",
+          "ty": null
+        }
+      ],
+      "id": "b11793485#1.0001",
+      "la": null,
+      "li": null,
+      "pr": "bf:note",
+      "ty": null
+    },
+    {
+      "bn": [
+        {
+          "id": null,
+          "la": null,
+          "li": "Note",
+          "pr": "bf:noteType",
+          "ty": null
+        },
+        {
+          "id": null,
+          "la": null,
+          "li": "Some items transcribed by Fats Waller.",
+          "pr": "rdfs:label",
+          "ty": null
+        },
+        {
+          "id": "bf:Note",
+          "la": null,
+          "li": null,
+          "pr": "rdf:type",
+          "ty": null
+        }
+      ],
+      "id": "b11793485#1.0002",
+      "la": null,
+      "li": null,
+      "pr": "bf:note",
+      "ty": null
+    },
+    {
+      "bn": [
+        {
+          "id": null,
+          "la": null,
+          "li": "Note",
+          "pr": "bf:noteType",
+          "ty": null
+        },
+        {
+          "id": null,
+          "la": null,
+          "li": "Words by Andy Razaf, George Brown, Joe Young, Alexander Hill, Ray Klages, Billy Rose, George Marion, Jr., and R. Stanley Adams",
+          "pr": "rdfs:label",
+          "ty": null
+        },
+        {
+          "id": "bf:Note",
+          "la": null,
+          "li": null,
+          "pr": "rdf:type",
+          "ty": null
+        }
+      ],
+      "id": "b11793485#1.0003",
+      "la": null,
+      "li": null,
+      "pr": "bf:note",
+      "ty": null
+    },
+    {
+      "bn": [
+        {
+          "id": null,
+          "la": null,
+          "li": "Note",
+          "pr": "bf:noteType",
+          "ty": null
+        },
+        {
+          "id": null,
+          "la": null,
+          "li": "Various publishers, chiefly New York: Mills Music, Inc.",
+          "pr": "rdfs:label",
+          "ty": null
+        },
+        {
+          "id": "bf:Note",
+          "la": null,
+          "li": null,
+          "pr": "rdf:type",
+          "ty": null
+        }
+      ],
+      "id": "b11793485#1.0004",
+      "la": null,
+      "li": null,
+      "pr": "bf:note",
+      "ty": null
+    },
+    {
+      "bn": [
+        {
+          "id": null,
+          "la": null,
+          "li": "Note",
+          "pr": "bf:noteType",
+          "ty": null
+        },
+        {
+          "id": null,
+          "la": null,
+          "li": "Some songs from the musical revues \"Hot chocolates\" \"Load of coal,\" \"Early to bed,\" \"Spades are trump\" and from the musical motion picture \"Stormy Weather.\".",
+          "pr": "rdfs:label",
+          "ty": null
+        },
+        {
+          "id": "bf:Note",
+          "la": null,
+          "li": null,
+          "pr": "rdf:type",
+          "ty": null
+        }
+      ],
+      "id": "b11793485#1.0005",
+      "la": null,
+      "li": null,
+      "pr": "bf:note",
+      "ty": null
+    },
+    {
+      "bn": [
+        {
+          "id": null,
+          "la": null,
+          "li": "Note",
+          "pr": "bf:noteType",
+          "ty": null
+        },
+        {
+          "id": null,
+          "la": null,
+          "li": "Some items are arrangements of arias from the operas \"Martha\", \"The Bohemian Girl,\" \"Lucia di Lammermour,\" \"Cavalleria Rusticana,\" \"Les Millions D'Arlequin\", \"Il Trovatore\", \"I Pagliacci,\" \"Rigoletto\" and \"Faust.\"",
+          "pr": "rdfs:label",
+          "ty": null
+        },
+        {
+          "id": "bf:Note",
+          "la": null,
+          "li": null,
+          "pr": "rdf:type",
+          "ty": null
+        }
+      ],
+      "id": "b11793485#1.0006",
+      "la": null,
+      "li": null,
+      "pr": "bf:note",
+      "ty": null
+    },
+    {
+      "bn": [
+        {
+          "id": null,
+          "la": null,
+          "li": "Note",
+          "pr": "bf:noteType",
+          "ty": null
+        },
+        {
+          "id": null,
+          "la": null,
+          "li": "As featured by Fats Waller, Jo Stafford, Merle Johnston, Lew Conrad, Eddie Peabody, Gene Austin, George Olsen, Gray Gordon's Tic-Toc Rhythm Orchestra, Julian Woodworth and his Clintonians, Paul Tremaine and his Aristocrats of Modern Music, George Hall and his orchestra, Heller Sisters and Brother Lynch, Ozzie Nelson and his Orchestra and Leo Reisman and his Victor Recording Orchestra.",
+          "pr": "rdfs:label",
+          "ty": null
+        },
+        {
+          "id": "bf:Note",
+          "la": null,
+          "li": null,
+          "pr": "rdf:type",
+          "ty": null
+        }
+      ],
+      "id": "b11793485#1.0007",
+      "la": null,
+      "li": null,
+      "pr": "bf:note",
+      "ty": null
+    },
+    {
+      "bn": [
+        {
+          "id": null,
+          "la": null,
+          "li": "Note",
+          "pr": "bf:noteType",
+          "ty": null
+        },
+        {
+          "id": null,
+          "la": null,
+          "li": "Cover illustrations include several caricatured drawings of Fats Waller playing the piano; photographs of Fats Waller, Lena Horne, Bill Robinson, Cab Calloway, Jo Stafford, Merle Johnston, Lew Conrad, Eddie Peabody, Gene Austin, George Olsen, Gray Gordon, Julian Woodworth, Paul Tremaine, George Hall, Ozzie Nelson, Leo Reisman and Haller Sisters and Brother Lynch on covers.",
+          "pr": "rdfs:label",
+          "ty": null
+        },
+        {
+          "id": "bf:Note",
+          "la": null,
+          "li": null,
+          "pr": "rdf:type",
+          "ty": null
+        }
+      ],
+      "id": "b11793485#1.0008",
+      "la": null,
+      "li": null,
+      "pr": "bf:note",
+      "ty": null
+    },
+    {
+      "bn": [
+        {
+          "id": null,
+          "la": null,
+          "li": "Note",
+          "pr": "bf:noteType",
+          "ty": null
+        },
+        {
+          "id": null,
+          "la": null,
+          "li": "Title and first line finding aids available.",
+          "pr": "rdfs:label",
+          "ty": null
+        },
+        {
+          "id": "bf:Note",
+          "la": null,
+          "li": null,
+          "pr": "rdf:type",
+          "ty": null
+        }
+      ],
+      "id": "b11793485#1.0009",
+      "la": null,
+      "li": null,
+      "pr": "bf:note",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "1955",
+      "pr": "dbo:endDate",
+      "ty": "xsd:integer"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "1924",
+      "pr": "dbo:startDate",
+      "ty": "xsd:integer"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Link, Harry, 1896-1956.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Brooks, Harry, 1895-1970.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Holmes, John.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Redman, Don.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Johnson, J. C., 1896-1981.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Hill, Alexander.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Carter, Benny.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Kirkeby, Ed.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Williams, Clarence, 1893-1965.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Arlen, Harold, 1905-1986.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Layton, Turner",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "McHugh, Jimmy, 1894-1969.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Jones, Isham, 1894-1956.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Flowtow, Friedrich von, 1812-1883.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Balfe, M. W. (Michael William), 1808-1870.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Saint-Saëns, Camille, 1835-1921.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Mascagni, Pietro, 1863-1945.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Drigo, Riccardo, 1846-1930.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Verdi, Giuseppe, 1813-1901.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Leoncavallo, Ruggiero, 1858-1919.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Gounod, Charles, 1818-1893.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Razaf, Andy, 1895-1973.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Brown, George.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Young, Joe, 1889-1939.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Klages, Roy.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Rose, Billy, 1899-1966.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Marion, George, Jr., 1899-1968,",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Adams, R. Stanley.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Stafford, Jo.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Johnston, Merle.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Conrad, Lew.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Peabody, Eddie.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Austin, Gene.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Hill, Alexander.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Gordon Gray.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Nelson, Ozzie, 1906-1975.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Olsen, George.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Hall, George.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Reisman, Leo, 1897-1961.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Woodworth, Julian.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Tremaine, Paul.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Clarence Williams Music Company.",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Heller Sisters and Brother Lynch. prf",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Tic-Toc Rhythm Orchestra. prf",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Clintonians. prf",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Aristocrats of Modern Music. prf",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Victor Recording Orchestra. prf",
+      "pr": "dc:contributor",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Waller, Fats, 1904-1943.",
+      "pr": "dc:creator",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "1924",
+      "pr": "dc:date",
+      "ty": "xsd:integer"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Waller, Fats, 1904-1943.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Harne, Lena.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Robinson, Bill, 1878-1949.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Calloway, Cab, 1907-1994.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Stafford, Jo.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Johnston, Merle.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Conrad, Lew.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Peabody, Eddie.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Austin, Gene.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Olsen, George.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Hall, George.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Nelson, Ozzie, 1906-1975.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Reisman, Leo, 1897-1961.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Tremaine, Paul.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Gordon Gray.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Woodworth, Julian.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Heller Sisters and Brother Lynch.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "African Americans -- Music.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Songs with piano.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Piano music.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Operas -- Excerpts, Arranged.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Musicals -- Excerpts -- Vocal scores with piano.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Popular music -- 1921-1930.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Popular music -- 1931-1940.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Popular music -- 1941-1950.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Popular music -- 1951-1960.",
+      "pr": "dc:subject",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Selections",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Ain't cha glad?",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Ain't misbehavin'.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "(What did I do to be) Alone and blue.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Angeline.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Anita.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Apple of my eye.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "(What did I do to be so) Black and blue.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Bohemian girl.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Cavalleria Rusticana.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Concentratin'.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Early to bed.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Fats Waller album of favorite songs and piano transcriptions.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Fats Waller's original piano conceptions.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Fats Waller's Scottish piano conceptions.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Fats Waller's Swing sessions for the piano.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Faust.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Foolin' myself.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Francis & Day's album of Fats Waller's musical rhythms.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Home alone blues.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Honeysuckle rose.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Hot chocolates.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "I'm crazy 'bout my baby.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "I'm more than satisfied.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "I've got a feeling I'm falling.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "I pagliacci.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "If it ain't love.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Il trovatore.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Joint is jumpin.'",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Keep a song in your soul.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Keepin' out of mischief now.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Ladies who sing with the band.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Load of coal.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Lucia di Lammermoor.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Martha.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Millions D'arlequin.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Moppin' and boppin'.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "My fate is in your hands.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "My heart's at ease.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "On rainy days.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Rigoletto.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Rollin' down the river.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Sheltered by the stars.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Sittin' up waitin' for you.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Slightly less than wonderful.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Smashing thirds.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Spades are trump.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Spider and fly.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Squeeze me.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Strange as it seems.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Stormy weather.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Swinging the operas.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Take it from me.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Tall timber.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "There's a man in my life.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "This is so nice.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "When Gabriel blows his horn.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "When the nylons bloom again.",
+      "pr": "dcterms:alternative",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "1924",
+      "pr": "dcterms:created",
+      "ty": "xsd:integer"
+    },
+    {
+      "bn": null,
+      "id": "11793485",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier",
+      "ty": "nypl:Bnumber"
+    },
+    {
+      "bn": null,
+      "id": "lang:eng",
+      "la": "English",
+      "li": null,
+      "pr": "dcterms:language",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Ain't cha glad? (4 copies) -- Ain't misbehavin' -- (What did I do to be) Alone and blue -- Angeline -- Anita -- The apple of my eye -- (What did I do to be so) Black and blue. -- Concentratin' (on you) -- The Fats Waller album of favorite songs and piano transcriptions -- Fats Waller's original piano conceptions -- Fats Waller's Scottish piano conceptions -- Fats Waller's swing sessions for the piano -- Foolin' myself -- Francis & Day's album of Fats Waller Musical Rhythms. -- Home alone blues -- Honeysuckle rose (4 copies) -- I'm crazy 'bout my baby (3 copies) -- I'm more than satisfied -- I've got a feeling I'm falling -- If it aint love (2 copies) -- The joint is jumpin' -- Keep a song in your soul -- Keepin' out of mischief now -- (3 copies) -- The ladies who sing with the band -- (2 copies) -- Moppin' and boppin' -- My fate is in your hands (3 copies) -- My heart's at ease -- On rainy days -- Rollin' down the river (3 copies) -- Sheltered by the stars (3 copies) -- Sittin' up waitin' for you -- Slightly less than wonderful (2 copies) -- Smashing thirds -- The spider and the fly (5 copies) -- Squeeze me -- Strange as it seems -- Swingin' the operas -- Take it from me (3 copies) -- Tall timber (2 copies) -- There's a man in my life (2 copies) -- This is so nice (4 copies) -- When Gabriel blows his horn -- When the nylons bloom again.",
+      "pr": "dcterms:tableOfContents",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "[Vocal and instrumental music",
+      "pr": "dcterms:title",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": "resourcetypes:not",
+      "la": "Notated music",
+      "li": null,
+      "pr": "dcterms:type",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": "loc:scd",
+      "la": "Schomburg Center - Manuscripts & Archives",
+      "li": null,
+      "pr": "nypl:catalogBibLocation",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "73 scores : col. ill., ports. ;",
+      "pr": "nypl:extent",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "1924-1955.",
+      "pr": "nypl:publicationStatement",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Sc Scores Waller",
+      "pr": "nypl:shelfMark",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed",
+      "ty": "xsd:boolean"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "[Vocal and instrumental music / composed, arranged, transcribed and performed by Fats Waller and others].",
+      "pr": "nypl:titleDisplay",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Selections",
+      "pr": "nypl:uniformTitle",
+      "ty": null
+    },
+    {
+      "bn": null,
+      "id": "nypl:Collection",
+      "la": null,
+      "li": null,
+      "pr": "rdfs:type",
+      "ty": null
+    }
+  ],
+  "item_statements": [
+    {
+      "s": "i33299584",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Sc Scores Waller",
+      "pr": "bf:physicalLocation",
+      "ty": null
+    },
+    {
+      "s": "i33299584",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available",
+      "li": null,
+      "pr": "bf:status",
+      "ty": null
+    },
+    {
+      "s": "i33299584",
+      "bn": null,
+      "id": "accessMessage:1",
+      "la": "Use in library",
+      "li": null,
+      "pr": "nypl:accessMessage",
+      "ty": null
+    },
+    {
+      "s": "i33299584",
+      "bn": null,
+      "id": "urn:bnum:b11793485",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum",
+      "ty": null
+    },
+    {
+      "s": "i33299584",
+      "bn": null,
+      "id": "catalogItemType:7",
+      "la": "printed music, non-circ",
+      "li": null,
+      "pr": "nypl:catalogItemType",
+      "ty": null
+    },
+    {
+      "s": "i33299584",
+      "bn": null,
+      "id": "loc:scdd2",
+      "la": "Schomburg Center - Manuscripts & Archives",
+      "li": null,
+      "pr": "nypl:holdingLocation",
+      "ty": null
+    },
+    {
+      "s": "i33299584",
+      "bn": null,
+      "id": "orgs:1116",
+      "la": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division",
+      "li": null,
+      "pr": "nypl:owner",
+      "ty": null
+    },
+    {
+      "s": "i33299584",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:requestable",
+      "ty": "xsd:boolean"
+    },
+    {
+      "s": "i33299584",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Sc Scores Waller",
+      "pr": "nypl:shelfMark",
+      "ty": null
+    },
+    {
+      "s": "i33299584",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed",
+      "ty": "xsd:boolean"
+    },
+    {
+      "s": "i33299584",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdfs:type",
+      "ty": null
+    }
+  ],
+  "holding_statements": []
+}

--- a/test/data/platform-endpoint-1acc9199416045c8da801daa3c0cbf5b.json
+++ b/test/data/platform-endpoint-1acc9199416045c8da801daa3c0cbf5b.json
@@ -1,0 +1,588 @@
+{
+  "data": {
+    "id": "11574666",
+    "nyplSource": "sierra-nypl",
+    "nyplType": "bib",
+    "updatedDate": "2021-04-25T12:22:04-04:00",
+    "createdDate": "2008-12-15T02:54:00-05:00",
+    "deletedDate": null,
+    "deleted": false,
+    "locations": [
+      {
+        "code": "scd",
+        "name": "Schomburg Center - Manuscripts & Archives"
+      },
+      {
+        "code": "mal",
+        "name": "SASB - Service Desk Rm 315"
+      }
+    ],
+    "suppressed": false,
+    "lang": {
+      "code": "eng",
+      "name": "English"
+    },
+    "title": "The problem of human destiny; or, The end of Providence in the world and man,",
+    "author": "Dewey, Orville, 1794-1882.",
+    "materialType": {
+      "code": "a  ",
+      "value": "BOOK/TEXT"
+    },
+    "bibLevel": {
+      "code": "m",
+      "value": "MONOGRAPH"
+    },
+    "publishYear": 1864,
+    "catalogDate": "2000-12-13",
+    "country": {
+      "code": "nyu",
+      "name": "New York (State)"
+    },
+    "normTitle": "problem of human destiny or the end of providence in the world and man",
+    "normAuthor": "dewey orville 1794 1882",
+    "standardNumbers": [],
+    "controlNumber": "NYPGR2076493-B",
+    "fixedFields": {
+      "24": {
+        "label": "Language",
+        "value": "eng",
+        "display": "English"
+      },
+      "25": {
+        "label": "Skip",
+        "value": "4",
+        "display": null
+      },
+      "26": {
+        "label": "Location",
+        "value": "multi",
+        "display": null
+      },
+      "27": {
+        "label": "COPIES",
+        "value": "3",
+        "display": null
+      },
+      "28": {
+        "label": "Cat. Date",
+        "value": "2000-12-13",
+        "display": null
+      },
+      "29": {
+        "label": "Bib Level",
+        "value": "m",
+        "display": "MONOGRAPH"
+      },
+      "30": {
+        "label": "Material Type",
+        "value": "a  ",
+        "display": "BOOK/TEXT"
+      },
+      "31": {
+        "label": "Bib Code 3",
+        "value": "-",
+        "display": null
+      },
+      "80": {
+        "label": "Record Type",
+        "value": "b",
+        "display": null
+      },
+      "81": {
+        "label": "Record Number",
+        "value": "11574666",
+        "display": null
+      },
+      "83": {
+        "label": "Created Date",
+        "value": "2008-12-15T02:54:00Z",
+        "display": null
+      },
+      "84": {
+        "label": "Updated Date",
+        "value": "2021-04-25T12:22:04Z",
+        "display": null
+      },
+      "85": {
+        "label": "No. of Revisions",
+        "value": "13",
+        "display": null
+      },
+      "86": {
+        "label": "Agency",
+        "value": "1",
+        "display": null
+      },
+      "89": {
+        "label": "Country",
+        "value": "nyu",
+        "display": "New York (State)"
+      },
+      "98": {
+        "label": "PDATE",
+        "value": "2021-04-25T12:14:39Z",
+        "display": null
+      },
+      "107": {
+        "label": "MARC Type",
+        "value": " ",
+        "display": null
+      }
+    },
+    "varFields": [
+      {
+        "fieldTag": "a",
+        "marcTag": "100",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Dewey, Orville,"
+          },
+          {
+            "tag": "d",
+            "content": "1794-1882."
+          }
+        ]
+      },
+      {
+        "fieldTag": "c",
+        "marcTag": "852",
+        "ind1": "8",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "h",
+            "content": "Sc Rare 124-D (Dewey, O. Problem of human destiny)"
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Providence and government of God."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Slavery."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Colonization."
+          }
+        ]
+      },
+      {
+        "fieldTag": "l",
+        "marcTag": "010",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "11023105"
+          }
+        ]
+      },
+      {
+        "fieldTag": "l",
+        "marcTag": "035",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "(OCoLC)2076493B"
+          }
+        ]
+      },
+      {
+        "fieldTag": "l",
+        "marcTag": "035",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "(WaOLN)nyp0013160"
+          }
+        ]
+      },
+      {
+        "fieldTag": "o",
+        "marcTag": "001",
+        "ind1": " ",
+        "ind2": " ",
+        "content": "NYPGR2076493-B",
+        "subfields": null
+      },
+      {
+        "fieldTag": "p",
+        "marcTag": "260",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "New York,"
+          },
+          {
+            "tag": "b",
+            "content": "J. Miller,"
+          },
+          {
+            "tag": "c",
+            "content": "1864."
+          }
+        ]
+      },
+      {
+        "fieldTag": "q",
+        "marcTag": "852",
+        "ind1": "8",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "h",
+            "content": "Sc Rare 124-D (Dewey, O. Problem of human destiny)"
+          }
+        ]
+      },
+      {
+        "fieldTag": "q",
+        "marcTag": "852",
+        "ind1": "8",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "h",
+            "content": "YCO (Dewey, O. Problem of human destiny. 1864)"
+          }
+        ]
+      },
+      {
+        "fieldTag": "q",
+        "marcTag": "852",
+        "ind1": "8",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "h",
+            "content": "YFH (Dewey, O. Problem of human destiny. 1864)"
+          }
+        ]
+      },
+      {
+        "fieldTag": "r",
+        "marcTag": "300",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "viii, 275 p."
+          },
+          {
+            "tag": "c",
+            "content": "24 cm."
+          }
+        ]
+      },
+      {
+        "fieldTag": "s",
+        "marcTag": "490",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Lowell lectures"
+          }
+        ]
+      },
+      {
+        "fieldTag": "s",
+        "marcTag": "830",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Lowell Institute lectures."
+          }
+        ]
+      },
+      {
+        "fieldTag": "t",
+        "marcTag": "245",
+        "ind1": "1",
+        "ind2": "4",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "The problem of human destiny;"
+          },
+          {
+            "tag": "b",
+            "content": "or, The end of Providence in the world and man,"
+          },
+          {
+            "tag": "c",
+            "content": "by Rev. Orville Dewey, D.D."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "End of Providence in the world and man."
+          }
+        ]
+      },
+      {
+        "fieldTag": "v",
+        "marcTag": "959",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": ".b26070352"
+          },
+          {
+            "tag": "b",
+            "content": "10-14-06"
+          },
+          {
+            "tag": "c",
+            "content": "09-19-92"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "856",
+        "ind1": "4",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "u",
+            "content": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=The+problem+of+human+destiny++or,+The+end+of+Providence+in+the+world+and+man,&Site=SCHRB&CallNumber=Sc+Rare+124-D+(Dewey,+O.+Problem+of+human+destiny)&Author=Dewey,+Orville,&ItemPlace=New+York,&ItemPublisher=J.+Miller,&Date=1864.&ItemInfo3=https://nypl-sierra-test.nypl.org/record=b115746663&ReferenceNumber=b115746663&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433034100226&ItemISxN=i103641531&Genre=Book-text&Location=Schomburg+Center"
+          },
+          {
+            "tag": "z",
+            "content": "Request Access to Special Collections Material"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "008",
+        "ind1": " ",
+        "ind2": " ",
+        "content": "760329s1864    nyu           000 0 eng  namu  ",
+        "subfields": null
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "005",
+        "ind1": " ",
+        "ind2": " ",
+        "content": "20001116190237.6",
+        "subfields": null
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "040",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "DLC"
+          },
+          {
+            "tag": "c",
+            "content": "MeB"
+          },
+          {
+            "tag": "d",
+            "content": "NN"
+          },
+          {
+            "tag": "d",
+            "content": "CStRLIN"
+          },
+          {
+            "tag": "d",
+            "content": "WaOLN"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "050",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "BD541"
+          },
+          {
+            "tag": "b",
+            "content": ".D5"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "856",
+        "ind1": "4",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "u",
+            "content": "http://hdl.handle.net/2027/nyp.33433006055358"
+          },
+          {
+            "tag": "z",
+            "content": "Full text available via HathiTrust"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "908",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "BD541"
+          },
+          {
+            "tag": "b",
+            "content": ".D5"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "997",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "sm"
+          },
+          {
+            "tag": "a",
+            "content": "hg"
+          },
+          {
+            "tag": "b",
+            "content": "12-13-00"
+          },
+          {
+            "tag": "c",
+            "content": "m"
+          },
+          {
+            "tag": "d",
+            "content": "a"
+          },
+          {
+            "tag": "e",
+            "content": "-"
+          },
+          {
+            "tag": "f",
+            "content": "eng"
+          },
+          {
+            "tag": "g",
+            "content": "nyu"
+          },
+          {
+            "tag": "h",
+            "content": "4"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "991",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "y",
+            "content": "2076493"
+          }
+        ]
+      },
+      {
+        "fieldTag": "_",
+        "marcTag": null,
+        "ind1": null,
+        "ind2": null,
+        "content": "00000nam  2200289u  4500",
+        "subfields": null
+      }
+    ]
+  }
+}

--- a/test/data/platform-endpoint-3796169b5837a2dd06892b09b735829a.json
+++ b/test/data/platform-endpoint-3796169b5837a2dd06892b09b735829a.json
@@ -1,0 +1,2509 @@
+{
+  "data": {
+    "id": "11793485",
+    "nyplSource": "sierra-nypl",
+    "nyplType": "bib",
+    "updatedDate": "2021-04-26T13:53:45-04:00",
+    "createdDate": "2008-12-15T07:26:00-05:00",
+    "deletedDate": null,
+    "deleted": false,
+    "locations": [
+      {
+        "code": "scd",
+        "name": "Schomburg Center - Manuscripts & Archives"
+      }
+    ],
+    "suppressed": false,
+    "lang": {
+      "code": "eng",
+      "name": "English"
+    },
+    "title": "[Vocal and instrumental music",
+    "author": "Waller, Fats, 1904-1943. cmp arr prf",
+    "materialType": {
+      "code": "c  ",
+      "value": "SCORE"
+    },
+    "bibLevel": {
+      "code": "c",
+      "value": "COLLECTION"
+    },
+    "publishYear": 1924,
+    "catalogDate": "2015-09-17",
+    "country": {
+      "code": "nyu",
+      "name": "New York (State)"
+    },
+    "normTitle": "vocal and instrumental music",
+    "normAuthor": "waller fats 1904 1943 cmp arr prf",
+    "standardNumbers": [],
+    "controlNumber": "NYPG091000037-C",
+    "fixedFields": {
+      "24": {
+        "label": "Language",
+        "value": "eng",
+        "display": "English"
+      },
+      "25": {
+        "label": "Skip",
+        "value": "0",
+        "display": null
+      },
+      "26": {
+        "label": "Location",
+        "value": "scd  ",
+        "display": "Schomburg Center - Manuscripts & Archives"
+      },
+      "27": {
+        "label": "COPIES",
+        "value": "1",
+        "display": null
+      },
+      "28": {
+        "label": "Cat. Date",
+        "value": "2015-09-17",
+        "display": null
+      },
+      "29": {
+        "label": "Bib Level",
+        "value": "c",
+        "display": "COLLECTION"
+      },
+      "30": {
+        "label": "Material Type",
+        "value": "c  ",
+        "display": "SCORE"
+      },
+      "31": {
+        "label": "Bib Code 3",
+        "value": "-",
+        "display": null
+      },
+      "80": {
+        "label": "Record Type",
+        "value": "b",
+        "display": null
+      },
+      "81": {
+        "label": "Record Number",
+        "value": "11793485",
+        "display": null
+      },
+      "83": {
+        "label": "Created Date",
+        "value": "2008-12-15T07:26:00Z",
+        "display": null
+      },
+      "84": {
+        "label": "Updated Date",
+        "value": "2021-04-26T13:53:45Z",
+        "display": null
+      },
+      "85": {
+        "label": "No. of Revisions",
+        "value": "12",
+        "display": null
+      },
+      "86": {
+        "label": "Agency",
+        "value": "1",
+        "display": null
+      },
+      "89": {
+        "label": "Country",
+        "value": "nyu",
+        "display": "New York (State)"
+      },
+      "98": {
+        "label": "PDATE",
+        "value": "2017-05-18T13:18:48Z",
+        "display": null
+      },
+      "107": {
+        "label": "MARC Type",
+        "value": " ",
+        "display": null
+      }
+    },
+    "varFields": [
+      {
+        "fieldTag": "a",
+        "marcTag": "100",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Waller, Fats,"
+          },
+          {
+            "tag": "d",
+            "content": "1904-1943."
+          },
+          {
+            "tag": "4",
+            "content": "cmp"
+          },
+          {
+            "tag": "4",
+            "content": "arr"
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Link, Harry,"
+          },
+          {
+            "tag": "d",
+            "content": "1896-1956."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Brooks, Harry,"
+          },
+          {
+            "tag": "d",
+            "content": "1895-1970."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Holmes, John."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Redman, Don."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Johnson, J. C.,"
+          },
+          {
+            "tag": "d",
+            "content": "1896-1981."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Hill, Alexander."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Carter, Benny."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Kirkeby, Ed."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Williams, Clarence,"
+          },
+          {
+            "tag": "d",
+            "content": "1893-1965."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Arlen, Harold,"
+          },
+          {
+            "tag": "d",
+            "content": "1905-1986."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Layton, Turner"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "McHugh, Jimmy,"
+          },
+          {
+            "tag": "d",
+            "content": "1894-1969."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Jones, Isham,"
+          },
+          {
+            "tag": "d",
+            "content": "1894-1956."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Flowtow, Friedrich von,"
+          },
+          {
+            "tag": "d",
+            "content": "1812-1883."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Balfe, M. W."
+          },
+          {
+            "tag": "q",
+            "content": "(Michael William),"
+          },
+          {
+            "tag": "d",
+            "content": "1808-1870."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Saint-Saëns, Camille,"
+          },
+          {
+            "tag": "d",
+            "content": "1835-1921."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Mascagni, Pietro,"
+          },
+          {
+            "tag": "d",
+            "content": "1863-1945."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Drigo, Riccardo,"
+          },
+          {
+            "tag": "d",
+            "content": "1846-1930."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Verdi, Giuseppe,"
+          },
+          {
+            "tag": "d",
+            "content": "1813-1901."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Leoncavallo, Ruggiero,"
+          },
+          {
+            "tag": "d",
+            "content": "1858-1919."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Gounod, Charles,"
+          },
+          {
+            "tag": "d",
+            "content": "1818-1893."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Razaf, Andy,"
+          },
+          {
+            "tag": "d",
+            "content": "1895-1973."
+          },
+          {
+            "tag": "4",
+            "content": "lyr"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Brown, George."
+          },
+          {
+            "tag": "4",
+            "content": "lyr"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Young, Joe,"
+          },
+          {
+            "tag": "d",
+            "content": "1889-1939."
+          },
+          {
+            "tag": "4",
+            "content": "lyr"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Klages, Roy."
+          },
+          {
+            "tag": "4",
+            "content": "lyr"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Rose, Billy,"
+          },
+          {
+            "tag": "d",
+            "content": "1899-1966."
+          },
+          {
+            "tag": "4",
+            "content": "lyr"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Marion, George,"
+          },
+          {
+            "tag": "c",
+            "content": "Jr.,"
+          },
+          {
+            "tag": "d",
+            "content": "1899-1968,"
+          },
+          {
+            "tag": "4",
+            "content": "lyr"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Adams, R. Stanley."
+          },
+          {
+            "tag": "4",
+            "content": "lyr"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Stafford, Jo."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Johnston, Merle."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Conrad, Lew."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Peabody, Eddie."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Austin, Gene."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Hill, Alexander."
+          },
+          {
+            "tag": "4",
+            "content": "lyr"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Gordon Gray."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Nelson, Ozzie,"
+          },
+          {
+            "tag": "d",
+            "content": "1906-1975."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Olsen, George."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Hall, George."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Reisman, Leo,"
+          },
+          {
+            "tag": "d",
+            "content": "1897-1961."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Woodworth, Julian."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Tremaine, Paul."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "710",
+        "ind1": "2",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Clarence Williams Music Company."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "710",
+        "ind1": "2",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Heller Sisters and Brother Lynch."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "710",
+        "ind1": "2",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Tic-Toc Rhythm Orchestra."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "710",
+        "ind1": "2",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Clintonians."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "710",
+        "ind1": "2",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Aristocrats of Modern Music."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "710",
+        "ind1": "2",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Victor Recording Orchestra."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Waller, Fats,"
+          },
+          {
+            "tag": "d",
+            "content": "1904-1943."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Harne, Lena."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Robinson, Bill,"
+          },
+          {
+            "tag": "d",
+            "content": "1878-1949."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Calloway, Cab,"
+          },
+          {
+            "tag": "d",
+            "content": "1907-1994."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Stafford, Jo."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Johnston, Merle."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Conrad, Lew."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Peabody, Eddie."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Austin, Gene."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Olsen, George."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Hall, George."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Nelson, Ozzie,"
+          },
+          {
+            "tag": "d",
+            "content": "1906-1975."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Reisman, Leo,"
+          },
+          {
+            "tag": "d",
+            "content": "1897-1961."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Tremaine, Paul."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Gordon Gray."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Woodworth, Julian."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "610",
+        "ind1": "2",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Heller Sisters and Brother Lynch."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "African Americans"
+          },
+          {
+            "tag": "x",
+            "content": "Music."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Songs with piano."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Piano music."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Operas"
+          },
+          {
+            "tag": "v",
+            "content": "Excerpts, Arranged."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Musicals"
+          },
+          {
+            "tag": "x",
+            "content": "Excerpts"
+          },
+          {
+            "tag": "v",
+            "content": "Vocal scores with piano."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Popular music"
+          },
+          {
+            "tag": "y",
+            "content": "1921-1930."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Popular music"
+          },
+          {
+            "tag": "y",
+            "content": "1931-1940."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Popular music"
+          },
+          {
+            "tag": "y",
+            "content": "1941-1950."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Popular music"
+          },
+          {
+            "tag": "y",
+            "content": "1951-1960."
+          }
+        ]
+      },
+      {
+        "fieldTag": "l",
+        "marcTag": "035",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "NN-Sc 09100037"
+          }
+        ]
+      },
+      {
+        "fieldTag": "l",
+        "marcTag": "035",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "(WaOLN)nyp1803493"
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Some items with piano acc."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "By Thomas Waller, Harry Brooks, John Holmes, Harry Link, Donald Redman, J.C. Johnson, Alexander Hill, Benny Carter, Ed Kirkeby, Clarence Williams, Harold Arlen, J. Turner Layton Jimmy McHugh, Isham Jones, Friedrich von Flotow, M.W. Balfe, Camille Saint-Saens, Pietro Mascagni, R. Drigo, Guiseppe Verdi, Ruggiero Leoncavallo and Charles Gounod."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Some items transcribed by Fats Waller."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Words by Andy Razaf, George Brown, Joe Young, Alexander Hill, Ray Klages, Billy Rose, George Marion, Jr., and R. Stanley Adams"
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Various publishers, chiefly New York: Mills Music, Inc."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Some songs from the musical revues \"Hot chocolates\" \"Load of coal,\" \"Early to bed,\" \"Spades are trump\" and from the musical motion picture \"Stormy Weather.\"."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Some items are arrangements of arias from the operas \"Martha\", \"The Bohemian Girl,\" \"Lucia di Lammermour,\" \"Cavalleria Rusticana,\" \"Les Millions D'Arlequin\", \"Il Trovatore\", \"I Pagliacci,\" \"Rigoletto\" and \"Faust.\""
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "As featured by Fats Waller, Jo Stafford, Merle Johnston, Lew Conrad, Eddie Peabody, Gene Austin, George Olsen, Gray Gordon's Tic-Toc Rhythm Orchestra, Julian Woodworth and his Clintonians, Paul Tremaine and his Aristocrats of Modern Music, George Hall and his orchestra, Heller Sisters and Brother Lynch, Ozzie Nelson and his Orchestra and Leo Reisman and his Victor Recording Orchestra."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Cover illustrations include several caricatured drawings of Fats Waller playing the piano; photographs of Fats Waller, Lena Horne, Bill Robinson, Cab Calloway, Jo Stafford, Merle Johnston, Lew Conrad, Eddie Peabody, Gene Austin, George Olsen, Gray Gordon, Julian Woodworth, Paul Tremaine, George Hall, Ozzie Nelson, Leo Reisman and Haller Sisters and Brother Lynch on covers."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Title and first line finding aids available."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "505",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Ain't cha glad? (4 copies) -- Ain't misbehavin' -- (What did I do to be) Alone and blue -- Angeline -- Anita -- The apple of my eye -- (What did I do to be so) Black and blue. -- Concentratin' (on you) -- The Fats Waller album of favorite songs and piano transcriptions -- Fats Waller's original piano conceptions -- Fats Waller's Scottish piano conceptions -- Fats Waller's swing sessions for the piano -- Foolin' myself -- Francis & Day's album of Fats Waller Musical Rhythms. -- Home alone blues -- Honeysuckle rose (4 copies) -- I'm crazy 'bout my baby (3 copies) -- I'm more than satisfied -- I've got a feeling I'm falling -- If it aint love (2 copies) -- The joint is jumpin' -- Keep a song in your soul -- Keepin' out of mischief now -- (3 copies) -- The ladies who sing with the band -- (2 copies) -- Moppin' and boppin' -- My fate is in your hands (3 copies) -- My heart's at ease -- On rainy days -- Rollin' down the river (3 copies) -- Sheltered by the stars (3 copies) -- Sittin' up waitin' for you -- Slightly less than wonderful (2 copies) -- Smashing thirds -- The spider and the fly (5 copies) -- Squeeze me -- Strange as it seems -- Swingin' the operas -- Take it from me (3 copies) -- Tall timber (2 copies) -- There's a man in my life (2 copies) -- This is so nice (4 copies) -- When Gabriel blows his horn -- When the nylons bloom again."
+          }
+        ]
+      },
+      {
+        "fieldTag": "o",
+        "marcTag": "001",
+        "ind1": " ",
+        "ind2": " ",
+        "content": "NYPG091000037-C",
+        "subfields": null
+      },
+      {
+        "fieldTag": "p",
+        "marcTag": "260",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "c",
+            "content": "1924-1955."
+          }
+        ]
+      },
+      {
+        "fieldTag": "q",
+        "marcTag": "852",
+        "ind1": "8",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "h",
+            "content": "Sc Scores Waller"
+          }
+        ]
+      },
+      {
+        "fieldTag": "r",
+        "marcTag": "300",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "73 scores :"
+          },
+          {
+            "tag": "b",
+            "content": "col. ill., ports. ;"
+          },
+          {
+            "tag": "c",
+            "content": "32 cm. or smaller."
+          }
+        ]
+      },
+      {
+        "fieldTag": "t",
+        "marcTag": "245",
+        "ind1": "0",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "[Vocal and instrumental music /"
+          },
+          {
+            "tag": "c",
+            "content": "composed, arranged, transcribed and performed by Fats Waller and others]."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Ain't cha glad?"
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Ain't misbehavin'."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "(What did I do to be) Alone and blue."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Angeline."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Anita."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Apple of my eye."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "(What did I do to be so) Black and blue."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Bohemian girl."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Cavalleria Rusticana."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Concentratin'."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Early to bed."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Fats Waller album of favorite songs and piano transcriptions."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Fats Waller's original piano conceptions."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Fats Waller's Scottish piano conceptions."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Fats Waller's Swing sessions for the piano."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Faust."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Foolin' myself."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Francis & Day's album of Fats Waller's musical rhythms."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Home alone blues."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Honeysuckle rose."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Hot chocolates."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "I'm crazy 'bout my baby."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "I'm more than satisfied."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "I've got a feeling I'm falling."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "I pagliacci."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "If it ain't love."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Il trovatore."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Joint is jumpin.'"
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Keep a song in your soul."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Keepin' out of mischief now."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Ladies who sing with the band."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Load of coal."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Lucia di Lammermoor."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Martha."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Millions D'arlequin."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Moppin' and boppin'."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "My fate is in your hands."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "My heart's at ease."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "On rainy days."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Rigoletto."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Rollin' down the river."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Sheltered by the stars."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Sittin' up waitin' for you."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Slightly less than wonderful."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Smashing thirds."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Spades are trump."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Spider and fly."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Squeeze me."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Strange as it seems."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Stormy weather."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Swinging the operas."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Take it from me."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Tall timber."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "There's a man in my life."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "This is so nice."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "When Gabriel blows his horn."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "When the nylons bloom again."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "799",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Schomburg NEH Automated Access to Special Collections Project."
+          }
+        ]
+      },
+      {
+        "fieldTag": "v",
+        "marcTag": "959",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": ".b28479312"
+          },
+          {
+            "tag": "b",
+            "content": "09-26-08"
+          },
+          {
+            "tag": "c",
+            "content": "01-08-94"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "856",
+        "ind1": "4",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "u",
+            "content": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=[Vocal+and+instrumental+music+/&Site=SCHMA&CallNumber=Sc+Scores+Waller&Author=Waller,+Fats,&Date=1924-1955.&ItemInfo3=https://nypl-sierra-test.nypl.org/record=b117934859&ReferenceNumber=b117934859&ItemInfo1=USE+IN+LIBRARY&ItemISxN=i332995847&Genre=Score&Location=Schomburg+Center"
+          },
+          {
+            "tag": "z",
+            "content": "Request Access to Special Collections Material"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "003",
+        "ind1": " ",
+        "ind2": " ",
+        "content": "CStRLIN",
+        "subfields": null
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "008",
+        "ind1": " ",
+        "ind2": " ",
+        "content": "920618i19241955nyuzzz         n    eng dccc a ",
+        "subfields": null
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "005",
+        "ind1": " ",
+        "ind2": " ",
+        "content": "19990913094118.4",
+        "subfields": null
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "040",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "NN"
+          },
+          {
+            "tag": "c",
+            "content": "NN"
+          },
+          {
+            "tag": "d",
+            "content": "WaOLN"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "945",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": ".b117934859"
+          },
+          {
+            "tag": "b",
+            "content": "11-22-10"
+          },
+          {
+            "tag": "c",
+            "content": "12-15-08"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "949",
+        "ind1": " ",
+        "ind2": "1",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "z",
+            "content": "8528"
+          },
+          {
+            "tag": "i",
+            "content": "BARCODE-SC"
+          },
+          {
+            "tag": "h",
+            "content": "31"
+          },
+          {
+            "tag": "t",
+            "content": "7"
+          },
+          {
+            "tag": "l",
+            "content": "scdd2"
+          },
+          {
+            "tag": "s",
+            "content": "b"
+          },
+          {
+            "tag": "o",
+            "content": "1"
+          },
+          {
+            "tag": "m",
+            "content": "PLEASE REPLACE \"BARCODE-SC\" WHEN ITEM IS BARCODED, CAT/KTS, 2015-09-17"
+          },
+          {
+            "tag": "a",
+            "content": "Sc Scores Waller"
+          },
+          {
+            "tag": "v",
+            "content": "CAT/kts"
+          }
+        ]
+      },
+      {
+        "fieldTag": "_",
+        "marcTag": null,
+        "ind1": null,
+        "ind2": null,
+        "content": "00000ccc  2201921 a 4500",
+        "subfields": null
+      }
+    ]
+  }
+}

--- a/test/data/platform-endpoint-45f0300c32b3b77e51981057855c9c7c.json
+++ b/test/data/platform-endpoint-45f0300c32b3b77e51981057855c9c7c.json
@@ -1,0 +1,2509 @@
+{
+  "data": {
+    "id": "11793485",
+    "nyplSource": "sierra-nypl",
+    "nyplType": "bib",
+    "updatedDate": "2021-04-26T13:53:45-04:00",
+    "createdDate": "2008-12-15T07:26:00-05:00",
+    "deletedDate": null,
+    "deleted": false,
+    "locations": [
+      {
+        "code": "scd",
+        "name": "Schomburg Center - Manuscripts & Archives"
+      }
+    ],
+    "suppressed": false,
+    "lang": {
+      "code": "eng",
+      "name": "English"
+    },
+    "title": "[Vocal and instrumental music",
+    "author": "Waller, Fats, 1904-1943. cmp arr prf",
+    "materialType": {
+      "code": "c  ",
+      "value": "SCORE"
+    },
+    "bibLevel": {
+      "code": "c",
+      "value": "COLLECTION"
+    },
+    "publishYear": 1924,
+    "catalogDate": "2015-09-17",
+    "country": {
+      "code": "nyu",
+      "name": "New York (State)"
+    },
+    "normTitle": "vocal and instrumental music",
+    "normAuthor": "waller fats 1904 1943 cmp arr prf",
+    "standardNumbers": [],
+    "controlNumber": "NYPG091000037-C",
+    "fixedFields": {
+      "24": {
+        "label": "Language",
+        "value": "eng",
+        "display": "English"
+      },
+      "25": {
+        "label": "Skip",
+        "value": "0",
+        "display": null
+      },
+      "26": {
+        "label": "Location",
+        "value": "scd  ",
+        "display": "Schomburg Center - Manuscripts & Archives"
+      },
+      "27": {
+        "label": "COPIES",
+        "value": "1",
+        "display": null
+      },
+      "28": {
+        "label": "Cat. Date",
+        "value": "2015-09-17",
+        "display": null
+      },
+      "29": {
+        "label": "Bib Level",
+        "value": "c",
+        "display": "COLLECTION"
+      },
+      "30": {
+        "label": "Material Type",
+        "value": "c  ",
+        "display": "SCORE"
+      },
+      "31": {
+        "label": "Bib Code 3",
+        "value": "-",
+        "display": null
+      },
+      "80": {
+        "label": "Record Type",
+        "value": "b",
+        "display": null
+      },
+      "81": {
+        "label": "Record Number",
+        "value": "11793485",
+        "display": null
+      },
+      "83": {
+        "label": "Created Date",
+        "value": "2008-12-15T07:26:00Z",
+        "display": null
+      },
+      "84": {
+        "label": "Updated Date",
+        "value": "2021-04-26T13:53:45Z",
+        "display": null
+      },
+      "85": {
+        "label": "No. of Revisions",
+        "value": "12",
+        "display": null
+      },
+      "86": {
+        "label": "Agency",
+        "value": "1",
+        "display": null
+      },
+      "89": {
+        "label": "Country",
+        "value": "nyu",
+        "display": "New York (State)"
+      },
+      "98": {
+        "label": "PDATE",
+        "value": "2017-05-18T13:18:48Z",
+        "display": null
+      },
+      "107": {
+        "label": "MARC Type",
+        "value": " ",
+        "display": null
+      }
+    },
+    "varFields": [
+      {
+        "fieldTag": "a",
+        "marcTag": "100",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Waller, Fats,"
+          },
+          {
+            "tag": "d",
+            "content": "1904-1943."
+          },
+          {
+            "tag": "4",
+            "content": "cmp"
+          },
+          {
+            "tag": "4",
+            "content": "arr"
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Link, Harry,"
+          },
+          {
+            "tag": "d",
+            "content": "1896-1956."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Brooks, Harry,"
+          },
+          {
+            "tag": "d",
+            "content": "1895-1970."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Holmes, John."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Redman, Don."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Johnson, J. C.,"
+          },
+          {
+            "tag": "d",
+            "content": "1896-1981."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Hill, Alexander."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Carter, Benny."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Kirkeby, Ed."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Williams, Clarence,"
+          },
+          {
+            "tag": "d",
+            "content": "1893-1965."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Arlen, Harold,"
+          },
+          {
+            "tag": "d",
+            "content": "1905-1986."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Layton, Turner"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "McHugh, Jimmy,"
+          },
+          {
+            "tag": "d",
+            "content": "1894-1969."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Jones, Isham,"
+          },
+          {
+            "tag": "d",
+            "content": "1894-1956."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Flowtow, Friedrich von,"
+          },
+          {
+            "tag": "d",
+            "content": "1812-1883."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Balfe, M. W."
+          },
+          {
+            "tag": "q",
+            "content": "(Michael William),"
+          },
+          {
+            "tag": "d",
+            "content": "1808-1870."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Saint-Saëns, Camille,"
+          },
+          {
+            "tag": "d",
+            "content": "1835-1921."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Mascagni, Pietro,"
+          },
+          {
+            "tag": "d",
+            "content": "1863-1945."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Drigo, Riccardo,"
+          },
+          {
+            "tag": "d",
+            "content": "1846-1930."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Verdi, Giuseppe,"
+          },
+          {
+            "tag": "d",
+            "content": "1813-1901."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Leoncavallo, Ruggiero,"
+          },
+          {
+            "tag": "d",
+            "content": "1858-1919."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Gounod, Charles,"
+          },
+          {
+            "tag": "d",
+            "content": "1818-1893."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Razaf, Andy,"
+          },
+          {
+            "tag": "d",
+            "content": "1895-1973."
+          },
+          {
+            "tag": "4",
+            "content": "lyr"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Brown, George."
+          },
+          {
+            "tag": "4",
+            "content": "lyr"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Young, Joe,"
+          },
+          {
+            "tag": "d",
+            "content": "1889-1939."
+          },
+          {
+            "tag": "4",
+            "content": "lyr"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Klages, Roy."
+          },
+          {
+            "tag": "4",
+            "content": "lyr"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Rose, Billy,"
+          },
+          {
+            "tag": "d",
+            "content": "1899-1966."
+          },
+          {
+            "tag": "4",
+            "content": "lyr"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Marion, George,"
+          },
+          {
+            "tag": "c",
+            "content": "Jr.,"
+          },
+          {
+            "tag": "d",
+            "content": "1899-1968,"
+          },
+          {
+            "tag": "4",
+            "content": "lyr"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Adams, R. Stanley."
+          },
+          {
+            "tag": "4",
+            "content": "lyr"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Stafford, Jo."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Johnston, Merle."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Conrad, Lew."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Peabody, Eddie."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Austin, Gene."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Hill, Alexander."
+          },
+          {
+            "tag": "4",
+            "content": "lyr"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Gordon Gray."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Nelson, Ozzie,"
+          },
+          {
+            "tag": "d",
+            "content": "1906-1975."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Olsen, George."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Hall, George."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Reisman, Leo,"
+          },
+          {
+            "tag": "d",
+            "content": "1897-1961."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Woodworth, Julian."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Tremaine, Paul."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "710",
+        "ind1": "2",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Clarence Williams Music Company."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "710",
+        "ind1": "2",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Heller Sisters and Brother Lynch."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "710",
+        "ind1": "2",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Tic-Toc Rhythm Orchestra."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "710",
+        "ind1": "2",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Clintonians."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "710",
+        "ind1": "2",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Aristocrats of Modern Music."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "710",
+        "ind1": "2",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Victor Recording Orchestra."
+          },
+          {
+            "tag": "4",
+            "content": "prf"
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Waller, Fats,"
+          },
+          {
+            "tag": "d",
+            "content": "1904-1943."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Harne, Lena."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Robinson, Bill,"
+          },
+          {
+            "tag": "d",
+            "content": "1878-1949."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Calloway, Cab,"
+          },
+          {
+            "tag": "d",
+            "content": "1907-1994."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Stafford, Jo."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Johnston, Merle."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Conrad, Lew."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Peabody, Eddie."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Austin, Gene."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Olsen, George."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Hall, George."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Nelson, Ozzie,"
+          },
+          {
+            "tag": "d",
+            "content": "1906-1975."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Reisman, Leo,"
+          },
+          {
+            "tag": "d",
+            "content": "1897-1961."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Tremaine, Paul."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Gordon Gray."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "600",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Woodworth, Julian."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "610",
+        "ind1": "2",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Heller Sisters and Brother Lynch."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "African Americans"
+          },
+          {
+            "tag": "x",
+            "content": "Music."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Songs with piano."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Piano music."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Operas"
+          },
+          {
+            "tag": "v",
+            "content": "Excerpts, Arranged."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Musicals"
+          },
+          {
+            "tag": "x",
+            "content": "Excerpts"
+          },
+          {
+            "tag": "v",
+            "content": "Vocal scores with piano."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Popular music"
+          },
+          {
+            "tag": "y",
+            "content": "1921-1930."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Popular music"
+          },
+          {
+            "tag": "y",
+            "content": "1931-1940."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Popular music"
+          },
+          {
+            "tag": "y",
+            "content": "1941-1950."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Popular music"
+          },
+          {
+            "tag": "y",
+            "content": "1951-1960."
+          }
+        ]
+      },
+      {
+        "fieldTag": "l",
+        "marcTag": "035",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "NN-Sc 09100037"
+          }
+        ]
+      },
+      {
+        "fieldTag": "l",
+        "marcTag": "035",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "(WaOLN)nyp1803493"
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Some items with piano acc."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "By Thomas Waller, Harry Brooks, John Holmes, Harry Link, Donald Redman, J.C. Johnson, Alexander Hill, Benny Carter, Ed Kirkeby, Clarence Williams, Harold Arlen, J. Turner Layton Jimmy McHugh, Isham Jones, Friedrich von Flotow, M.W. Balfe, Camille Saint-Saens, Pietro Mascagni, R. Drigo, Guiseppe Verdi, Ruggiero Leoncavallo and Charles Gounod."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Some items transcribed by Fats Waller."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Words by Andy Razaf, George Brown, Joe Young, Alexander Hill, Ray Klages, Billy Rose, George Marion, Jr., and R. Stanley Adams"
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Various publishers, chiefly New York: Mills Music, Inc."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Some songs from the musical revues \"Hot chocolates\" \"Load of coal,\" \"Early to bed,\" \"Spades are trump\" and from the musical motion picture \"Stormy Weather.\"."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Some items are arrangements of arias from the operas \"Martha\", \"The Bohemian Girl,\" \"Lucia di Lammermour,\" \"Cavalleria Rusticana,\" \"Les Millions D'Arlequin\", \"Il Trovatore\", \"I Pagliacci,\" \"Rigoletto\" and \"Faust.\""
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "As featured by Fats Waller, Jo Stafford, Merle Johnston, Lew Conrad, Eddie Peabody, Gene Austin, George Olsen, Gray Gordon's Tic-Toc Rhythm Orchestra, Julian Woodworth and his Clintonians, Paul Tremaine and his Aristocrats of Modern Music, George Hall and his orchestra, Heller Sisters and Brother Lynch, Ozzie Nelson and his Orchestra and Leo Reisman and his Victor Recording Orchestra."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Cover illustrations include several caricatured drawings of Fats Waller playing the piano; photographs of Fats Waller, Lena Horne, Bill Robinson, Cab Calloway, Jo Stafford, Merle Johnston, Lew Conrad, Eddie Peabody, Gene Austin, George Olsen, Gray Gordon, Julian Woodworth, Paul Tremaine, George Hall, Ozzie Nelson, Leo Reisman and Haller Sisters and Brother Lynch on covers."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Title and first line finding aids available."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "505",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Ain't cha glad? (4 copies) -- Ain't misbehavin' -- (What did I do to be) Alone and blue -- Angeline -- Anita -- The apple of my eye -- (What did I do to be so) Black and blue. -- Concentratin' (on you) -- The Fats Waller album of favorite songs and piano transcriptions -- Fats Waller's original piano conceptions -- Fats Waller's Scottish piano conceptions -- Fats Waller's swing sessions for the piano -- Foolin' myself -- Francis & Day's album of Fats Waller Musical Rhythms. -- Home alone blues -- Honeysuckle rose (4 copies) -- I'm crazy 'bout my baby (3 copies) -- I'm more than satisfied -- I've got a feeling I'm falling -- If it aint love (2 copies) -- The joint is jumpin' -- Keep a song in your soul -- Keepin' out of mischief now -- (3 copies) -- The ladies who sing with the band -- (2 copies) -- Moppin' and boppin' -- My fate is in your hands (3 copies) -- My heart's at ease -- On rainy days -- Rollin' down the river (3 copies) -- Sheltered by the stars (3 copies) -- Sittin' up waitin' for you -- Slightly less than wonderful (2 copies) -- Smashing thirds -- The spider and the fly (5 copies) -- Squeeze me -- Strange as it seems -- Swingin' the operas -- Take it from me (3 copies) -- Tall timber (2 copies) -- There's a man in my life (2 copies) -- This is so nice (4 copies) -- When Gabriel blows his horn -- When the nylons bloom again."
+          }
+        ]
+      },
+      {
+        "fieldTag": "o",
+        "marcTag": "001",
+        "ind1": " ",
+        "ind2": " ",
+        "content": "NYPG091000037-C",
+        "subfields": null
+      },
+      {
+        "fieldTag": "p",
+        "marcTag": "260",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "c",
+            "content": "1924-1955."
+          }
+        ]
+      },
+      {
+        "fieldTag": "q",
+        "marcTag": "852",
+        "ind1": "8",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "h",
+            "content": "Sc Scores Waller"
+          }
+        ]
+      },
+      {
+        "fieldTag": "r",
+        "marcTag": "300",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "73 scores :"
+          },
+          {
+            "tag": "b",
+            "content": "col. ill., ports. ;"
+          },
+          {
+            "tag": "c",
+            "content": "32 cm. or smaller."
+          }
+        ]
+      },
+      {
+        "fieldTag": "t",
+        "marcTag": "245",
+        "ind1": "0",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "[Vocal and instrumental music /"
+          },
+          {
+            "tag": "c",
+            "content": "composed, arranged, transcribed and performed by Fats Waller and others]."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Ain't cha glad?"
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Ain't misbehavin'."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "(What did I do to be) Alone and blue."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Angeline."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Anita."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Apple of my eye."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "(What did I do to be so) Black and blue."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Bohemian girl."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Cavalleria Rusticana."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Concentratin'."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Early to bed."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Fats Waller album of favorite songs and piano transcriptions."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Fats Waller's original piano conceptions."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Fats Waller's Scottish piano conceptions."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Fats Waller's Swing sessions for the piano."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Faust."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Foolin' myself."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Francis & Day's album of Fats Waller's musical rhythms."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Home alone blues."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Honeysuckle rose."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Hot chocolates."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "I'm crazy 'bout my baby."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "I'm more than satisfied."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "I've got a feeling I'm falling."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "I pagliacci."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "If it ain't love."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Il trovatore."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Joint is jumpin.'"
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Keep a song in your soul."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Keepin' out of mischief now."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Ladies who sing with the band."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Load of coal."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Lucia di Lammermoor."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Martha."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Millions D'arlequin."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Moppin' and boppin'."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "My fate is in your hands."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "My heart's at ease."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "On rainy days."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Rigoletto."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Rollin' down the river."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Sheltered by the stars."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Sittin' up waitin' for you."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Slightly less than wonderful."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Smashing thirds."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Spades are trump."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Spider and fly."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Squeeze me."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Strange as it seems."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Stormy weather."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Swinging the operas."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Take it from me."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Tall timber."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "There's a man in my life."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "This is so nice."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "When Gabriel blows his horn."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "740",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "When the nylons bloom again."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "799",
+        "ind1": "0",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Schomburg NEH Automated Access to Special Collections Project."
+          }
+        ]
+      },
+      {
+        "fieldTag": "v",
+        "marcTag": "959",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": ".b28479312"
+          },
+          {
+            "tag": "b",
+            "content": "09-26-08"
+          },
+          {
+            "tag": "c",
+            "content": "01-08-94"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "856",
+        "ind1": "4",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "u",
+            "content": "https://othersite.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=[Vocal+and+instrumental+music+/&Site=SCHMA&CallNumber=Sc+Scores+Waller&Author=Waller,+Fats,&Date=1924-1955.&ItemInfo3=https://nypl-sierra-test.nypl.org/record=b117934859&ReferenceNumber=b117934859&ItemInfo1=USE+IN+LIBRARY&ItemISxN=i332995847&Genre=Score&Location=Schomburg+Center"
+          },
+          {
+            "tag": "z",
+            "content": "Request Access to Special Collections Material"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "003",
+        "ind1": " ",
+        "ind2": " ",
+        "content": "CStRLIN",
+        "subfields": null
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "008",
+        "ind1": " ",
+        "ind2": " ",
+        "content": "920618i19241955nyuzzz         n    eng dccc a ",
+        "subfields": null
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "005",
+        "ind1": " ",
+        "ind2": " ",
+        "content": "19990913094118.4",
+        "subfields": null
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "040",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "NN"
+          },
+          {
+            "tag": "c",
+            "content": "NN"
+          },
+          {
+            "tag": "d",
+            "content": "WaOLN"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "945",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": ".b117934859"
+          },
+          {
+            "tag": "b",
+            "content": "11-22-10"
+          },
+          {
+            "tag": "c",
+            "content": "12-15-08"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "949",
+        "ind1": " ",
+        "ind2": "1",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "z",
+            "content": "8528"
+          },
+          {
+            "tag": "i",
+            "content": "BARCODE-SC"
+          },
+          {
+            "tag": "h",
+            "content": "31"
+          },
+          {
+            "tag": "t",
+            "content": "7"
+          },
+          {
+            "tag": "l",
+            "content": "scdd2"
+          },
+          {
+            "tag": "s",
+            "content": "b"
+          },
+          {
+            "tag": "o",
+            "content": "1"
+          },
+          {
+            "tag": "m",
+            "content": "PLEASE REPLACE \"BARCODE-SC\" WHEN ITEM IS BARCODED, CAT/KTS, 2015-09-17"
+          },
+          {
+            "tag": "a",
+            "content": "Sc Scores Waller"
+          },
+          {
+            "tag": "v",
+            "content": "CAT/kts"
+          }
+        ]
+      },
+      {
+        "fieldTag": "_",
+        "marcTag": null,
+        "ind1": null,
+        "ind2": null,
+        "content": "00000ccc  2201921 a 4500",
+        "subfields": null
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR is the backend part of Aeon integration, which includes:

 * New configuration params to control what item locations are considered Aeon locations, what item shelfmarks (by regex) are considered Aeon shelfmarks, and additional config to authenticate the Bib service.
 * When item is identified as an Aeon item, we request the relevant bib from the BibService, parse `856 $u` out of it, and add that URL as a new `aeonUrl` property of the identified items.
 * Tests
 * Minor update to `print-serialized` script, which aids local ad hoc testing

https://jira.nypl.org/browse/SCC-2666