### PR TITLE
SCC-2876 -  Saves oclc identifiers as idOclc

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -175,6 +175,7 @@ const resourcesProperties = {
     properties: {
       accessMessage: mappingTemplates.entity,
       accessMessage_packed: mappingTemplates.packed,
+      aeonUrl: mappingTemplates.exactString,
       catalogItemType: mappingTemplates.entity,
       catalogItemType_packed: mappingTemplates.packed,
       deliveryLocation: mappingTemplates.entity,
@@ -237,6 +238,7 @@ const resourcesProperties = {
   },
   numAvailable: mappingTemplates.number,
   numItems: mappingTemplates.number,
+  nyplSource: mappingTemplates.exactString,
   parallelTitle: mappingTemplates.fulltextFolded,
   parallelTitleDisplay: mappingTemplates.fulltextFolded,
   parallelSeriesStatement: mappingTemplates.fulltextWithRawFolded,

--- a/lib/kms-helper.js
+++ b/lib/kms-helper.js
@@ -4,7 +4,7 @@ const log = require('loglevel')
 function decrypt (encrypted) {
   return new Promise((resolve, reject) => {
     const kms = new AWS.KMS()
-    kms.decrypt({ CiphertextBlob: new Buffer(encrypted, 'base64') }, (err, data) => {
+    kms.decrypt({ CiphertextBlob: Buffer.from(encrypted, 'base64') }, (err, data) => {
       if (err) return reject(err)
 
       var decrypted = data.Plaintext.toString('ascii')

--- a/test/bib-serializations-test.js
+++ b/test/bib-serializations-test.js
@@ -462,6 +462,22 @@ describe('Bib Serializations', function () {
         })
       })
     })
+
+    it('should add idOclc for identifiers with type "nypl:Oclc" on NYPL bibs', function () {
+      return Bib.byId('b10011745').then((bib) => {
+        return ResourceSerializer.serialize(bib).then((serialized) => {
+          assert(serialized.idOclc.indexOf('4131153') >= 0)
+        })
+      })
+    })
+
+    it('should add idOclc for identifiers with type "nypl:Oclc" on partner bibs', function () {
+      return Bib.byId('hb990049360620203941').then((bib) => {
+        return ResourceSerializer.serialize(bib).then((serialized) => {
+          assert(serialized.idOclc.indexOf('31447739') >= 0)
+        })
+      })
+    })
   })
 
   describe('items', function () {

--- a/test/data/b10011745.json
+++ b/test/data/b10011745.json
@@ -155,6 +155,14 @@
     },
     {
       "bn": null,
+      "id": "4131153",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier",
+      "ty": "nypl:Oclc"
+    },
+    {
+      "bn": null,
       "id": "lang:eng",
       "la": "English",
       "li": null,

--- a/test/data/hb990049360620203941.json
+++ b/test/data/hb990049360620203941.json
@@ -289,6 +289,14 @@
     },
     {
       "bn": null,
+      "id": "31447739",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier",
+      "ty": "nypl:Oclc"
+    },
+    {
+      "bn": null,
       "id": "lang:uzb",
       "la": "Uzbek",
       "li": null,


### PR DESCRIPTION
Updates tests to confirm that identifiers tagged with type `nypl:Oclc`
are saved to `idOclc`.

This depends on NYPL_CORE_VERSION v1.45a+

https://jira.nypl.org/browse/SCC-2876

Two other housekeeping updates:
1.  Change use of `new Buffer` to `Buffer.from` (former is being deprecated)
2. Adds two bib properties that were manually added to the mapping, but
never added to code. This is just a formality, but could help us recover
should we need to re-create the mapping from code. Properties added:
 - nyplSource
 - aeonUrl