### PR TITLE
Fix int to integer

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -250,7 +250,7 @@ const resourcesProperties = {
   parallelDisplayField: {
     properties: {
       fieldName: { type: 'keyword', index: true },
-      index: { type: mappingTemplates.number, index: true },
+      index: mappingTemplates.number,
       value: { type: 'text', index: true }
     }
   },

--- a/lib/index.js
+++ b/lib/index.js
@@ -250,7 +250,7 @@ const resourcesProperties = {
   parallelDisplayField: {
     properties: {
       fieldName: { type: 'keyword', index: true },
-      index: { type: 'int', index: true },
+      index: { type: 'integer', index: true },
       value: { type: 'text', index: true }
     }
   },

--- a/lib/index.js
+++ b/lib/index.js
@@ -250,7 +250,7 @@ const resourcesProperties = {
   parallelDisplayField: {
     properties: {
       fieldName: { type: 'keyword', index: true },
-      index: { type: 'integer', index: true },
+      index: { type: mappingTemplates.number, index: true },
       value: { type: 'text', index: true }
     }
   },


### PR DESCRIPTION
Fixes a mistake in an earlier PR, the ElasticSearch type for integers is `integer`, not `int`