### PR TITLE
Fix misnamed parallelPublisherLiteral

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -255,7 +255,7 @@ const resourcesProperties = {
       value: { type: 'text', index: true }
     }
   },
-  parallelPublisher: mappingTemplates.fulltextFolded,
+  parallelPublisherLiteral: mappingTemplates.fulltextFolded,
   partOf: mappingTemplates.exactString,
   placeOfPublication: mappingTemplates.exactString,
   publicDomain: mappingTemplates.boolean,
@@ -517,8 +517,8 @@ function mappingsDiff (localMapping, remoteMapping) {
   // Create a report consisting of { localOnlyProperties: [...], unequalMappings: [...], remoteOnlyMappings: [] }
   let report = Object.keys(localMapping)
     .reduce((report, property) => {
-      // If it's nested, recurse:
-      if (localMapping[property].type === 'nested') {
+      // If it's nested/object, recurse:
+      if (localMapping[property].properties) {
         let nestedReport = mappingsDiff(localMapping[property].properties, remoteMapping[property] ? remoteMapping[property].properties : {})
         return Object.keys(nestedReport).reduce((newReport, key) => {
           newReport[key] = newReport[key].concat(nestedReport[key].map((instance) => {


### PR DESCRIPTION
Fix: Change parallelPublisher to parallelPublisherLiteral so that it
agrees with it's referrent: publisherLiteral. This change has already
been applied to QA and Prod ES indexes. This is just a formality.

Also addresses minor bug in the mapping-check script, causing `object`
type fields to be reported as having different config locally vs remote.