### PR TITLE
extract electronic resource count

### DIFF
--- a/lib/serializers/resource-serializer.js
+++ b/lib/serializers/resource-serializer.js
@@ -258,8 +258,8 @@ class ResourceSerializer extends EsSerializer {
       this.statements.uris = this.statements.uris.concat(this.object._items.map((i) => [this.statements.uri, i.id].join('-')))
       // Extract number of electronic resources. These are previously combined into one item with electronic locator links in the discovery store poster
       this.object._items.forEach((item) => {
-        if (item.has('nypl:electronicLocator') || item.has('bf:electronicLocator')) {
-          const numElectronicResources = item.statements('nypl:electronicLocator').length + item.statements('bf:electronicLocator').length
+        if (item.has('bf:electronicLocator')) {
+          const numElectronicResources = item.statements('bf:electronicLocator').length
           this.addStatement('numElectronicResources', numElectronicResources)
         }
       })

--- a/lib/serializers/resource-serializer.js
+++ b/lib/serializers/resource-serializer.js
@@ -155,19 +155,19 @@ class ResourceSerializer extends EsSerializer {
       }
     })
 
-    // Add straightforward literals that need to preserve the order they were
-    // saved in the store (By default, anything extracted via this.object.each
-    // is sorted by object_id/object_literal)
-    ; [
-      'Contents',
-      'Contents title'
-    ].forEach((name) => {
-      bibFieldMapper.getMapping(name, (spec) => {
-        this.object.literals(spec.pred).forEach((literal) => {
-          this.addStatement(spec.jsonLdKey, literal)
+      // Add straightforward literals that need to preserve the order they were
+      // saved in the store (By default, anything extracted via this.object.each
+      // is sorted by object_id/object_literal)
+      ;[
+        'Contents',
+        'Contents title'
+      ].forEach((name) => {
+        bibFieldMapper.getMapping(name, (spec) => {
+          this.object.literals(spec.pred).forEach((literal) => {
+            this.addStatement(spec.jsonLdKey, literal)
+          })
         })
       })
-    })
 
     // Having added properties that require some special handling above,
     // now add a bunch of properties that are straightforward literals:
@@ -256,7 +256,13 @@ class ResourceSerializer extends EsSerializer {
     if (this.object._items) {
       // Add `[bibid]-[itemid]` to bib-level `uris` property for each item to aid retrieval of unified bib-item object
       this.statements.uris = this.statements.uris.concat(this.object._items.map((i) => [this.statements.uri, i.id].join('-')))
-
+      // Extract number of electronic resources. These are previously combined into one item with electronic locator links in the discovery store poster
+      this.object._items.forEach((item) => {
+        if (item.has('nypl:electronicLocator') || item.has('bf:electronicLocator')) {
+          const numElectronicResources = item.statements('nypl:electronicLocator').length + item.statements('bf:electronicLocator').length
+          this.addStatement('numElectronicResources', numElectronicResources)
+        }
+      })
       // Serialize each `_items` through ResourceItemSerializer
       promises.push(Promise.all(this.object._items.map((item) => ResourceItemSerializer.serialize(item, this.object))).then((itemsSerialization) => {
         // Filtering out null (suppressed) items
@@ -334,7 +340,7 @@ ResourceSerializer.sortableShelfMark = (shelfMark) => {
   const replace = (m0, fullMatch, label, labelWhitespace, labelText, number) => {
     // If we matched a label, build string from label and then pad number
     return label ? `${label.toLowerCase()}${ResourceSerializer.zeroPadString(number)}`
-    // Otherwise just pad whole match (presumably it's a line terminating num):
+      // Otherwise just pad whole match (presumably it's a line terminating num):
       : ResourceSerializer.zeroPadString(fullMatch)
   }
   return shelfMark
@@ -410,8 +416,8 @@ function parseIdentifierFromStatement (statement) {
     value = statement.literal('rdf:value')
     identifierStatus = statement.literal('bf:identifierStatus')
 
-  // Otherwise treat statement as a single statmeent (with type packed into
-  // value as a prefix or stored in object_type)
+    // Otherwise treat statement as a single statmeent (with type packed into
+    // value as a prefix or stored in object_type)
   } else {
     type = statement.object_type
     if (!type && /^urn:\w+:/.test(statement.object_id)) {

--- a/test/bib-serializations-test.js
+++ b/test/bib-serializations-test.js
@@ -96,6 +96,14 @@ describe('Bib Serializations', function () {
       })
     })
 
+    it('should create a numElectronicResources property', () => {
+      return Bib.byId('b10011374').then((bib) => {
+        return ResourceSerializer.serialize(bib).then((serialized) => {
+          assert.equal(serialized.numElectronicResources, 4)
+        })
+      })
+    })
+
     it('should remove extraneous colons from isbn', () => {
       return Bib.byId('bCrazyIsbn').then((bib) => {
         return ResourceSerializer.serialize(bib).then((serialized) => {


### PR DESCRIPTION
This code loops through the _items array within the bib serializer. It checks for presence of two different electronicLocator predicates, bf:electronicLocator and nypl:electronicLocator. It creates the property numElectronicResources with the value of the number of statements that have that predicate. 