### PR TITLE
Fix broken sorting of some range values

### DIFF
--- a/lib/serializers/resource-item-serializer.js
+++ b/lib/serializers/resource-item-serializer.js
@@ -136,17 +136,16 @@ class ResourceItemSerializer extends EsSerializer {
     let lowestVol = null
     const volumeRangeMapping = itemFieldMapper.getMapping('Volume Range')
     if (this.object.has(volumeRangeMapping.pred)) {
-      lowestVol = this.object.literals(volumeRangeMapping.pred)
-        .sort((r1, r2) => r1[0] < r2[0] ? -1 : 1)
-        .shift()[0]
+      lowestVol = utils.lowestRangeValue(
+        this.object.literals(volumeRangeMapping.pred)
+      )
     }
     let lowestDate = null
     const dateRangeMapping = itemFieldMapper.getMapping('Date Range')
     if (this.object.has(dateRangeMapping.pred)) {
-      lowestDate = this.object.literals(dateRangeMapping.pred)
-        .map((range) => range[0])
-        .sort()
-        .shift()
+      lowestDate = utils.lowestRangeValue(
+        this.object.literals(dateRangeMapping.pred)
+      )
     }
     if (lowestVol || lowestDate) {
       // Build enumerationChronology_sort as the lowest vol number (left-

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -110,13 +110,31 @@ exports.isArrayWithValues = function (a, maxDepth = 2, depth = 0) {
 exports.arrayToEsRangeObject = function (rangeArray) {
   if (!Array.isArray(rangeArray) || rangeArray.length !== 2) throw Error('Invalid array passed to arrayToEsRangeObject')
 
-  const [gte, lte] = rangeArray
-    // Sort values to correct for swapped upper/lower bounds
-    .sort()
+  const [gte, lte] = exports.fixMisorderedRange(rangeArray)
   return {
     gte,
     lte
   }
+}
+
+/**
+ *  Given an array of ranges (a 2-D array of 2-element arrays), returns
+ *  the lowest lower bounds in any of the ranges
+ */
+exports.lowestRangeValue = function (arrayOfRanges) {
+  return arrayOfRanges
+    .map(exports.fixMisorderedRange)
+    .sort((r1, r2) => r1[0] < r2[0] ? -1 : 1)
+    .shift()[0]
+}
+
+/**
+ *  Given a range (a 2-element array), returns a new array with elements ordered
+ */
+exports.fixMisorderedRange = function (range) {
+  // Sort values to correct for swapped upper/lower bounds
+  return [].concat(range)
+    .sort((v1, v2) => v1 < v2 ? -1 : 1)
 }
 
 /**

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -189,5 +189,33 @@ describe('Utils', function () {
       expect(utils.arrayToEsRangeObject([10, 1]))
         .to.deep.equal({ gte: 1, lte: 10 })
     })
+
+    it('should correct misordered array without also being broken by Node\'s regretable default comparator', function () {
+      // "The default sort order is ascending, built upon converting the elements into strings"
+      expect(utils.arrayToEsRangeObject([1000, 2]))
+        .to.deep.equal({ gte: 2, lte: 1000 })
+    })
+  })
+
+  describe('fixMisorderedRange', function () {
+    it('fixes misordered range', function () {
+      expect(utils.fixMisorderedRange([3, 1])).to.deep.eq([1, 3])
+      expect(utils.fixMisorderedRange([10000, 1])).to.deep.eq([1, 10000])
+    })
+
+    it('fixes misordered range without mutation', function () {
+      const orig = [3, 1]
+      expect(utils.fixMisorderedRange(orig)).to.deep.eq([1, 3])
+      expect(orig).to.deep.eq([3, 1])
+    })
+  })
+
+  describe('lowestRangeValue', function () {
+    it('identifies lowest value in range', function () {
+      expect(utils.lowestRangeValue([[1, 2], [3, 6]])).to.eq(1)
+      expect(utils.lowestRangeValue([[9, 10], [6, 7]])).to.eq(6)
+      // Relying on the function to auto correct bad ranges:
+      expect(utils.lowestRangeValue([[90, 1], [6, 7]])).to.eq(1)
+    })
   })
 })


### PR DESCRIPTION
Fixes bug when sorting some range values due to Node's regretable default comparator, which converts elements into strings, leading to this nonsense:

```
> [ 2, 116 ].sort()
[ 116, 2 ]
```

Also general refactoring for DRY